### PR TITLE
Rename application to Phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-![CardinalKit Logo](https://raw.githubusercontent.com/CardinalKit/.github/main/assets/ck-header-light.png#gh-light-mode-only)
-![CardinalKit Logo](https://raw.githubusercontent.com/CardinalKit/.github/main/assets/ck-header-dark.png#gh-dark-mode-only)
+# Phoenix Survey Builder
 
-# CardinalKit Survey Builder
-
-A React application that allows you to build healthcare surveys using the [HL7® FHIR® Questionnaire](https://www.hl7.org/fhir/questionnaire.html) internatinoal standard using an interactive, drag-and-drop interface, and export JSON to be used in CardinalKit iOS and Android applications to deliver surveys to patients.
+A web application that allows you to build healthcare surveys using the [HL7® FHIR® Questionnaire](https://www.hl7.org/fhir/questionnaire.html) international data standard using an interactive, drag-and-drop interface, and export JSON to be used in CardinalKit/Spezi iOS and Android applications to deliver surveys to patients.
 
 ## Features
 - Drag and drop survey creation
@@ -15,19 +12,21 @@ A React application that allows you to build healthcare surveys using the [HL7®
 - Node.js & npm
 
 ## Getting Started
-- To use the application online, visit https://cardinalkit.org/builder
+- To use the application online, visit https://spezi.health/phoenix
 - To run the application locally:
     - Clone this repository and run `npm install` in the root directory
     - Run `npm start` to start the application in development mode
     - Open `localhost:3000/builder` in your browser to view the application
 
-## License
-MIT
+## Contributors & License
+The Phoenix Survey Builder is licensed under the [MIT license](LICENSE).
+
+Phoenix is based on the [Structor](https://github.com/helsenorge/structor) project. We are grateful to the [Helse Norge](https://github.com/helsenorge) team for open-sourcing their work.
 
 ## Disclaimer
 HL7®, and FHIR® are the registered trademarks of Health Level Seven International and their use of these trademarks does not constitute an endorsement by HL7.
 
 This software is not intended to be a medical device.
 
-![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/CardinalKit/.github/main/assets/ck-footer-light.png#gh-light-mode-only)
-![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/CardinalKit/.github/main/assets/ck-footer-dark.png#gh-dark-mode-only)
+![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
+![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "cardinalkit-survey-builder",
+    "name": "phoenix-survey-builder",
     "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "cardinalkit-survey-builder",
+            "name": "phoenix-survey-builder",
             "version": "1.0.0",
             "dependencies": {
                 "@ckeditor/ckeditor5-react": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "cardinalkit-survey-builder",
+    "name": "phoenix-survey-builder",
     "version": "1.0.0",
     "private": true,
-    "homepage": "https://cardinalkit.org/builder",
+    "homepage": "https://spezi.health/phoenix",
     "dependencies": {
         "@ckeditor/ckeditor5-react": "^3.0.0",
         "@helsenorge/ckeditor5-build-markdown": "^24.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>CardinalKit Survey Builder</title>
+  <title>Phoenix Survey Builder</title>
 </head>
 
 <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "CardinalKit Interactive Questionnaire Builder",
-  "name": "CardinalKit Interactive Questionnaire Builder",
+  "short_name": "Phoenix Survey Builder",
+  "name": "Phoenix Survey Builder",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -116,7 +116,7 @@ const Navbar = ({
         <>
             <header ref={navBarRef}>
                 <div className="pull-left form-title">
-                    <h1><IconBtn type="x" title={t('Close')} onClick={() => {close()}} /><a className="survey-title-button" onClick={toggleFormDetails}>{title || 'CardinalKit Survey Builder'}</a></h1>
+                    <h1><IconBtn type="x" title={t('Close')} onClick={() => {close()}} /><a className="survey-title-button" onClick={toggleFormDetails}>{title || 'Phoenix Survey Builder'}</a></h1>
                 </div>
 
                 <div className="pull-right">

--- a/src/helpers/initPredefinedValueSet.ts
+++ b/src/helpers/initPredefinedValueSet.ts
@@ -1,6 +1,6 @@
 import { ValueSet } from '../types/fhir';
 
-export const predefinedValueSetUri = 'http://cardinalkit.org/fhir/ValueSet/Predefined';
+export const predefinedValueSetUri = 'http://spezi.health/fhir/ValueSet/Predefined';
 
 export const initPredefinedValueSet = [
     {
@@ -38,7 +38,7 @@ export const initPredefinedValueSet = [
         name: 'urn:oid:1102',
         title: 'Yes / No / Do not know',
         status: 'draft',
-        publisher: 'CardinalKit',
+        publisher: 'Stanford University',
         compose: {
             include: [
                 {
@@ -69,7 +69,7 @@ export const initPredefinedValueSet = [
         name: 'urn:oid:9523',
         title: 'Yes / No / Unsure',
         status: 'draft',
-        publisher: 'CardinalKit',
+        publisher: 'Stanford Biodesign Digital Health',
         compose: {
             include: [
                 {

--- a/src/helpers/uriHelper.ts
+++ b/src/helpers/uriHelper.ts
@@ -1,7 +1,7 @@
 import createUUID from './CreateUUID';
 
 export const createUrlUUID = (): string => {
-    return `http://cardinalkit.org/fhir/questionnaire/${createUUID()}`;
+    return `http://spezi.health/fhir/questionnaire/${createUUID()}`;
 }
 
 export const createUriUUID = (): string => {
@@ -13,5 +13,5 @@ export const isUriValid = (uri: string): boolean => {
 };
 
 export enum CodingSystemType {
-    valueSetTqqc = 'http://cardinalkit.org/fhir/ValueSet/TQQC',
+    valueSetTqqc = 'http://spezi.health/fhir/ValueSet/TQQC',
 }

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -5,7 +5,7 @@ import { TreeContextProvider } from '../store/treeStore/treeStore';
 export default function Routes(): JSX.Element {
     return (
         <Switch>
-            <Route path="/builder" exact>
+            <Route path="/phoenix" exact>
                 <TreeContextProvider>
                     <FrontPage />
                 </TreeContextProvider>

--- a/src/store/treeStore/treeStore.tsx
+++ b/src/store/treeStore/treeStore.tsx
@@ -184,9 +184,9 @@ export const initialState: TreeState = {
         language: INITIAL_LANGUAGE.code,
         name: '',
         status: 'draft',
-        publisher: 'CardinalKit',
+        publisher: 'Stanford Biodesign Digital Health',
         meta: {
-            profile: ['http://cardinalkit.org/fhir/StructureDefinition/sdf-Questionnaire'],
+            profile: ['http://spezi.health/fhir/StructureDefinition/sdf-Questionnaire'],
             tag: [
                 {
                     system: 'urn:ietf:bcp:47',
@@ -213,7 +213,7 @@ export const initialState: TreeState = {
         ],
         contact: [
             {
-                name: 'http://cardinalkit.org',
+                name: 'http://spezi.health',
             },
         ],
         subjectType: ['Patient'],

--- a/src/views/FrontPage.tsx
+++ b/src/views/FrontPage.tsx
@@ -96,7 +96,7 @@ const FrontPage = (): JSX.Element => {
             {isMobileModalShown && (
                 <Modal title={t('Warning')} close={onCloseMobileModal} size={'small'}>
                     <div>
-                        <p>The CardinalKit survey builder works best on a large screen and may not appear properly on mobile devices.</p>
+                        <p>The Phoenix Survey Builder works best on a large screen and may not appear properly on mobile devices.</p>
                         <div className="modal-btn-bottom">
                             <div className="center-text">
                                 <Btn title={t('Ok')} type="button" variant="primary" onClick={onCloseMobileModal} />
@@ -133,10 +133,10 @@ const FrontPage = (): JSX.Element => {
             ) : (
                 <>
                     <header>
-                        <h1 className="form-title-frontpage">{`CardinalKit Survey Builder`}</h1>
+                        <h1 className="form-title-frontpage">{`Phoenix Survey Builder`}</h1>
                     </header>
                     <div className="frontpage">
-                        <img src={cardinalkitSpaceman} alt="CardinalKit Spaceman" width="200" className="spaceman" />
+                        <img src={cardinalkitSpaceman} alt="Spezi Spaceman" width="200" className="spaceman" />
                         <h2>{`Easily build a healthcare survey using HL7® FHIR®!`}</h2>
                         <div className="frontpage__infotext">
                             {t('You can start a new survey, or upload and continue to work on one you\'ve already started.')}
@@ -169,7 +169,7 @@ const FrontPage = (): JSX.Element => {
             )}
             <footer className="footer">
                 <p className="footer-text">
-                    An <a href="https://github.com/cardinalkit/builder">open-source project</a> of the <a href="https://cardinalkit.stanford.edu">CardinalKit</a> team at Stanford University.
+                    An <a href="https://github.com/StanfordBDHG/Phoenix">open-source project</a> of the <a href="https://bdh.stanford.edu">Biodesign Digital Health</a> team at Stanford University.
                 </p>
             </footer>
         </>


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Rename application to Phoenix

## :recycle: Current situation & Problem
The application is currently called *CardinalKit Survey Builder* and uses *cardinalkit.org/builder* as the URL.

## :bulb: Proposed solution
Renames the application to *Phoenix Survey Builder* and the URL to *spezi.health/phoenix*.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

