### PR TITLE
Migrate from higher-order component to hooks for react-dnd

### DIFF
--- a/src/components/AnchorMenu/AnchorMenu.tsx
+++ b/src/components/AnchorMenu/AnchorMenu.tsx
@@ -1,5 +1,5 @@
 import './AnchorMenu.css';
-import { DndProvider, DragSource, DragSourceConnector, ConnectDragSource } from 'react-dnd';
+import { DndProvider, useDrag, DragSourceConnector } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import React from 'react';
@@ -27,6 +27,7 @@ interface AnchorMenuProps {
     dispatch: React.Dispatch<ActionType>;
 }
 
+// Interface definition to describe the node structure of the questionnaire tree
 interface Node {
     title: string;
     hierarchy?: string;
@@ -40,6 +41,7 @@ interface ExtendedNode {
     path: string[];
 }
 
+// Event type definitions for moving nodes and toggling node visibility in the tree
 interface NodeMoveEvent {
     treeData: Node[];
     nextParentNode: Node;
@@ -56,22 +58,7 @@ interface NodeVisibilityToggleEvent {
 const newNodeLinkId = 'NEW';
 const externalNodeType = 'yourNodeType';
 
-const externalNodeSpec = {
-    // This needs to return an object with a property `node` in it.
-    // Object rest spread is recommended to avoid side effects of
-    // referencing the same object in different trees.
-    beginDrag: (componentProps: { node: Node }) => ({ node: { ...componentProps.node } }),
-};
-const externalNodeCollect = (connect: DragSourceConnector) => ({
-    connectDragSource: connect.dragSource(),
-    // Add props via react-dnd APIs to enable more visual
-    // customization of your component
-    // isDragging: monitor.isDragging(),
-    // didDrop: monitor.didDrop(),
-});
-
-const ExternalNodeBaseComponent = (props: { connectDragSource: ConnectDragSource; node: Node }): JSX.Element | null => {
-
+const YourExternalNodeComponent = ({ node }: { node: Node }): JSX.Element | null => {
     const getRelevantIcon = (type?: string) => {
         switch (type) {
             case IQuestionnaireItemType.group:
@@ -96,22 +83,28 @@ const ExternalNodeBaseComponent = (props: { connectDragSource: ConnectDragSource
                 return 'ion-help-circled';
         }
     };
+    
+const [{ isDragging }, drag] = useDrag(() => ({
+        type: externalNodeType,
+        item: { node: { ...node } },
+        collect: (monitor) => ({
+            isDragging: monitor.isDragging(),
+        }),
+    }));
 
-    return props.connectDragSource (
-    <div className="anchor-menu__dragcomponent">
-       <i className={getRelevantIcon(props.node.nodeType)} /> &nbsp; {props.node.nodeReadableType}
-    </div>, 
-    {
-        dropEffect: 'copy',
-    });
+    const opacity = isDragging ? 0.5 : 1;
+    return (
+        <div
+            className="anchor-menu__dragcomponent"
+            ref={drag}
+            style={{ opacity }}
+        >
+            <i className={getRelevantIcon(node.nodeType)} /> &nbsp; {node.nodeReadableType}
+        </div>
+    );
 };
 
-const YourExternalNodeComponent = DragSource(
-    externalNodeType,
-    externalNodeSpec,
-    externalNodeCollect,
-)(ExternalNodeBaseComponent);
-
+// The main component "AnchorMenu"
 const AnchorMenu = (props: AnchorMenuProps): JSX.Element => {
     const { t } = useTranslation();
     const [collapsedNodes, setCollapsedNodes] = React.useState<string[]>([]);

--- a/src/components/AnchorMenu/AnchorMenu.tsx
+++ b/src/components/AnchorMenu/AnchorMenu.tsx
@@ -1,5 +1,5 @@
 import './AnchorMenu.css';
-import { DndProvider, useDrag, DragSourceConnector } from 'react-dnd';
+import { DndProvider, useDrag } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import React from 'react';
@@ -83,8 +83,8 @@ const YourExternalNodeComponent = ({ node }: { node: Node }): JSX.Element | null
                 return 'ion-help-circled';
         }
     };
-    
-const [{ isDragging }, drag] = useDrag(() => ({
+
+    const [{ isDragging }, drag] = useDrag(() => ({
         type: externalNodeType,
         item: { node: { ...node } },
         collect: (monitor) => ({
@@ -93,6 +93,7 @@ const [{ isDragging }, drag] = useDrag(() => ({
     }));
 
     const opacity = isDragging ? 0.5 : 1;
+    
     return (
         <div
             className="anchor-menu__dragcomponent"
@@ -108,7 +109,7 @@ const [{ isDragging }, drag] = useDrag(() => ({
 const AnchorMenu = (props: AnchorMenuProps): JSX.Element => {
     const { t } = useTranslation();
     const [collapsedNodes, setCollapsedNodes] = React.useState<string[]>([]);
-    
+
 
     const mapToTreeData = (item: OrderItem[], hierarchy: string, parentLinkId?: string): Node[] => {
         return item
@@ -267,7 +268,7 @@ const AnchorMenu = (props: AnchorMenuProps): JSX.Element => {
                     <div className="anchor-menu__placeholder">
                         <div className="anchor-menu__info">
                             <i className="ion-android-hand" /> &nbsp;
-                            {'Drag a question type here to start building your survey!'}    
+                            {'Drag a question type here to start building your survey!'}
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Migrate from higher-order component to hooks for react-dnd

## :recycle: Current situation & Problem
The current application uses higher-order components for the react-dnd package. However, as of react-dnd v15, support for higher-order components has been dropped in favor of the `useDrag` hook. Upgrading to react-dnd v15 is required to update the react-sortable-tree package. All of these issues are blocking our ability to migrate to React 18.

## :bulb: Proposed solution
We will refactor the anchor menu component to use the `useDrag` hook instead of higher-order components.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

