### PR TITLE
Support creation of multiple selection questions

### DIFF
--- a/src/components/Question/QuestionType/Choice.tsx
+++ b/src/components/Question/QuestionType/Choice.tsx
@@ -9,17 +9,20 @@ import {
 
 import { QuestionnaireItem, QuestionnaireItemAnswerOption } from '../../../types/fhir';
 import Btn from '../../Btn/Btn';
-import { IItemProperty } from '../../../types/IQuestionnareItemType';
+import { IExtentionType, IItemProperty, IQuestionnaireItemType } from '../../../types/IQuestionnareItemType';
 import { TreeContext } from '../../../store/treeStore/treeStore';
 import { removeItemAttributeAction, updateItemAction } from '../../../store/treeStore/treeActions';
 
 import UriField from '../../FormField/UriField';
 import { removeItemExtension, setItemExtension } from '../../../helpers/extensionHelper';
 import FormField from '../../FormField/FormField';
+import ChoiceTypeSelect from './ChoiceTypeSelect';
 import SwitchBtn from '../../SwitchBtn/SwitchBtn';
 import { createUriUUID } from '../../../helpers/uriHelper';
 import DraggableAnswerOptions from '../../AnswerOption/DraggableAnswerOptions';
 import PredefinedValueSets from './PredefinedValueSets';
+import { ItemControlType, isItemControlCheckbox, isItemControlDropDown } from '../../../helpers/itemControl';
+import { checkboxExtension } from '../../../helpers/QuestionHelper';
 
 type Props = {
     item: QuestionnaireItem;
@@ -29,6 +32,13 @@ const Choice = ({ item }: Props): JSX.Element => {
     const { t } = useTranslation();
     const { dispatch, state } = useContext(TreeContext);
     const { qContained } = state;
+
+    const dispatchExtensionUpdate = (type: ItemControlType) => {
+        removeItemExtension(item, IExtentionType.itemControl, dispatch);
+        if (type === ItemControlType.checkbox && !isItemControlCheckbox(item)){
+            setItemExtension(item, checkboxExtension, dispatch);
+        }
+    }
 
     const dispatchUpdateItem = (
         name: IItemProperty,
@@ -55,8 +65,7 @@ const Choice = ({ item }: Props): JSX.Element => {
 
     return (
         <>
-            {/* 
-            NOTE: CK does not yet support 'open-choice' questions
+            <ChoiceTypeSelect item={item} dispatchExtentionUpdate={dispatchExtensionUpdate} />
             <FormField>
                 <SwitchBtn
                     onChange={() => {
@@ -70,7 +79,6 @@ const Choice = ({ item }: Props): JSX.Element => {
                     label={t('Allow free-text answer')}
                 />
             </FormField> 
-            */}
             <FormField>
                 <SwitchBtn
                     onChange={() => {

--- a/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
+++ b/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
@@ -1,10 +1,7 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
     isItemControlCheckbox,
-    isItemControlDropDown,
-    isItemControlRadioButton,
     ItemControlType,
 } from '../../../helpers/itemControl';
 import { QuestionnaireItem } from '../../../types/fhir';
@@ -22,10 +19,6 @@ const ChoiceTypeSelect = ({ item, dispatchExtentionUpdate }: Props): JSX.Element
     const getSelectedItemControlValue = () => {
         if (isItemControlCheckbox(item)) {
             return ItemControlType.checkbox;
-        } else if (isItemControlDropDown(item)) {
-            return ItemControlType.dropdown;
-        } else if (isItemControlRadioButton(item)) {
-            return ItemControlType.radioButton;
         }
         return ItemControlType.dynamic;
     };

--- a/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
+++ b/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
@@ -41,19 +41,11 @@ const ChoiceTypeSelect = ({ item, dispatchExtentionUpdate }: Props): JSX.Element
                     options={[
                         {
                             code: ItemControlType.dynamic,
-                            display: t('Dynamic'),
-                        },
-                        {
-                            code: ItemControlType.radioButton,
-                            display: t('Radio buttons'),
-                        },
-                        {
-                            code: ItemControlType.dropdown,
-                            display: t('Dropdown'),
+                            display: t('Allow selection of one value'),
                         },
                         {
                             code: ItemControlType.checkbox,
-                            display: t('Checkbox (Allow selection of multiple values)'),
+                            display: t('Allow selection of multiple values'),
                         },
                     ]}
                     name="choice-item-control-radio"

--- a/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
+++ b/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
@@ -34,11 +34,11 @@ const ChoiceTypeSelect = ({ item, dispatchExtentionUpdate }: Props): JSX.Element
                     options={[
                         {
                             code: ItemControlType.dynamic,
-                            display: t('Allow selection of one value'),
+                            display: t('Dynamic'),
                         },
                         {
                             code: ItemControlType.checkbox,
-                            display: t('Allow selection of multiple values'),
+                            display: t('Checkbox (Allows selection of multiple values)'),
                         },
                     ]}
                     name="choice-item-control-radio"


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign Digital Health Group open-source organization

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Support creation of multiple selection questions

## :recycle: Current situation & Problem
Currently we cannot create multiple choice questions that allow the user to select more than one option (usually rendered as a set of checkboxes).

## :bulb: Proposed solution
We add an option to multiple choice questions that allows questionnaire creators to toggle between allowing a single selection or multiple selections.

We also enable `open-choice` questions which are now supported by [ResearchKitOnFHIR](https://github.com/StanfordBDHG/ResearchKitOnFHIR).

### Related PRs
This functionality is being added to `ResearchKitOnFHIR` in the following PR https://github.com/StanfordBDHG/ResearchKitOnFHIR/pull/64. It is also already supported by [Android FHIR's Data Capture Library](https://github.com/google/android-fhir).

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

