### PR TITLE
Allow numerical input using a slider

### DIFF
--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -9,7 +9,6 @@ import {
     QuestionnaireItemAnswerOption,
     ValueSet,
     ValueSetComposeIncludeConcept,
-    Coding
 } from '../../types/fhir';
 import { IExtentionType, IItemProperty, IQuestionnaireItemType } from '../../types/IQuestionnareItemType';
 
@@ -217,31 +216,6 @@ const Question = (props: QuestionProps): JSX.Element => {
                                     }
                                 }} />
                             </FormField>
-                            {!(isDecimal || isQuantity) && <FormField>
-                                <SwitchBtn 
-                                    label={t('Display as a slider')} 
-                                    value={isSlider} 
-                                    onChange={(() => {
-                                        const newExtension = {
-                                            url: IExtentionType.itemControl,
-                                            valueCodeableConcept: {
-                                                coding: [
-                                                    {
-                                                        system: "http://hl7.org/fhir/questionnaire-item-control",
-                                                        code: "slider",
-                                                        display: "Slider"
-                                                        }
-                                                    ]
-                                                }
-                                            };
-                                            if (!isSlider) {
-                                                setItemExtension(props.item, newExtension, props.dispatch)
-                                            } else {
-                                                removeItemExtension(props.item, IExtentionType.itemControl, props.dispatch)
-                                            }
-                                        })}
-                                />
-                            </FormField>}
                         </>
                     )}
                     {(isDecimalOrQuantity) && (
@@ -273,59 +247,88 @@ const Question = (props: QuestionProps): JSX.Element => {
                         />
                     )}
                 </FormField>
-                {isSlider && <div className="horizontal equal">
-                    <FormField label={t('Slider min value')}>
-                        <input
-                            type="number"
-                            defaultValue={sliderMinValue}
-                            onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                if (!event.target.value) {
-                                    removeItemExtension(props.item, IExtentionType.minValue, props.dispatch);
-                                } else {
-                                    const extension = {
-                                        url: IExtentionType.minValue,
-                                        valueInteger: parseInt(event.target.value),
+                {!isDecimalOrQuantity && 
+                    <FormField>
+                        <SwitchBtn 
+                            label={t('Display as a slider')} 
+                            value={isSlider} 
+                            onChange={(() => {
+                                const newExtension = {
+                                    url: IExtentionType.itemControl,
+                                    valueCodeableConcept: {
+                                        coding: [
+                                            {
+                                                system: "http://hl7.org/fhir/questionnaire-item-control",
+                                                code: "slider",
+                                                display: "Slider"
+                                                }
+                                            ]
+                                        }
                                     };
-                                    setItemExtension(props.item, extension, props.dispatch);
-                                }
-                            }}
-                        ></input>
+                                    if (!isSlider) {
+                                        setItemExtension(props.item, newExtension, props.dispatch)
+                                    } else {
+                                        removeItemExtension(props.item, IExtentionType.itemControl, props.dispatch)
+                                    }
+                                })}
+                        />
                     </FormField>
-                    <FormField label={t('Slider max value')}>
-                        <input
-                            type="number"
-                            defaultValue={sliderMaxValue}
-                            onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                if (!event.target.value) {
-                                    removeItemExtension(props.item, IExtentionType.maxValue, props.dispatch);
-                                } else {
-                                    const extension = {
-                                        url: IExtentionType.maxValue,
-                                        valueInteger: parseInt(event.target.value),
-                                    };
-                                    setItemExtension(props.item, extension, props.dispatch);
-                                }
-                            }}
-                        ></input>
-                    </FormField>
-                    <FormField label={t('Slider step value')}>
-                        <input
-                            type="number"
-                            defaultValue={sliderStepValue}
-                            onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                if (!event.target.value) {
-                                    removeItemExtension(props.item, IExtentionType.questionnaireSliderStepValue, props.dispatch);
-                                } else {
-                                    const extension = {
-                                        url: IExtentionType.questionnaireSliderStepValue,
-                                        valueInteger: parseInt(event.target.value),
-                                    };
-                                    setItemExtension(props.item, extension, props.dispatch);
-                                }
-                            }}
-                        ></input>
-                    </FormField>
-                </div>}
+                }
+                {isSlider && 
+                    <div className="horizontal equal">
+                        <FormField label={t('Slider min value')}>
+                            <input
+                                type="number"
+                                defaultValue={sliderMinValue}
+                                onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    if (!event.target.value) {
+                                        removeItemExtension(props.item, IExtentionType.minValue, props.dispatch);
+                                    } else {
+                                        const extension = {
+                                            url: IExtentionType.minValue,
+                                            valueInteger: parseInt(event.target.value),
+                                        };
+                                        setItemExtension(props.item, extension, props.dispatch);
+                                    }
+                                }}
+                            ></input>
+                        </FormField>
+                        <FormField label={t('Slider max value')}>
+                            <input
+                                type="number"
+                                defaultValue={sliderMaxValue}
+                                onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    if (!event.target.value) {
+                                        removeItemExtension(props.item, IExtentionType.maxValue, props.dispatch);
+                                    } else {
+                                        const extension = {
+                                            url: IExtentionType.maxValue,
+                                            valueInteger: parseInt(event.target.value),
+                                        };
+                                        setItemExtension(props.item, extension, props.dispatch);
+                                    }
+                                }}
+                            ></input>
+                        </FormField>
+                        <FormField label={t('Slider step value')}>
+                            <input
+                                type="number"
+                                defaultValue={sliderStepValue}
+                                onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    if (!event.target.value) {
+                                        removeItemExtension(props.item, IExtentionType.questionnaireSliderStepValue, props.dispatch);
+                                    } else {
+                                        const extension = {
+                                            url: IExtentionType.questionnaireSliderStepValue,
+                                            valueInteger: parseInt(event.target.value),
+                                        };
+                                        setItemExtension(props.item, extension, props.dispatch);
+                                    }
+                                }}
+                            ></input>
+                        </FormField>
+                    </div>
+                }
                 {/* Sublabel is not currently supported 
                 {canTypeHaveSublabel(props.item) && (
                     <FormField label={t('Sublabel')} isOptional>

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -9,12 +9,13 @@ import {
     QuestionnaireItemAnswerOption,
     ValueSet,
     ValueSetComposeIncludeConcept,
+    Coding
 } from '../../types/fhir';
 import { IExtentionType, IItemProperty, IQuestionnaireItemType } from '../../types/IQuestionnareItemType';
 
 import { updateItemAction } from '../../store/treeStore/treeActions';
 import { isRecipientList } from '../../helpers/QuestionHelper';
-import { createMarkdownExtension, removeItemExtension } from '../../helpers/extensionHelper';
+import { createMarkdownExtension, removeItemExtension, setItemExtension, hasExtension } from '../../helpers/extensionHelper';
 import { isItemControlInline, isItemControlReceiverComponent, isItemControlHighlight } from '../../helpers/itemControl';
 
 import Accordion from '../Accordion/Accordion';
@@ -98,6 +99,7 @@ const Question = (props: QuestionProps): JSX.Element => {
     const isDecimal = props.item.type === IQuestionnaireItemType.decimal;
     const isQuantity = props.item.type === IQuestionnaireItemType.quantity;
     const isDecimalOrQuantity = isDecimal || isQuantity;
+
 
     // Adds instructions for the user
     const instructionType = (): JSX.Element => {
@@ -193,6 +195,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                         </FormField>
                     )}
                     {(isNumber) && (
+                        <>
                         <FormField>
                             <SwitchBtn label={t('Allow decimals')} value={isDecimalOrQuantity} onChange={() => {
                                 const newItemType = isDecimal || isQuantity
@@ -206,6 +209,32 @@ const Question = (props: QuestionProps): JSX.Element => {
                                 }
                             }} />
                         </FormField>
+                        <FormField>
+                    <SwitchBtn 
+                        label={t('Display as a slider')} 
+                        value={hasExtension(props.item, IExtentionType.itemControl)} 
+                        onChange={(() => {
+                            const newExtension = {
+                                url: IExtentionType.itemControl,
+                                valueCodeableConcept: {
+                                    coding: [
+                                        {
+                                            system: "http://hl7.org/fhir/questionnaire-item-control",
+                                            code: "slider",
+                                            display: "Slider"
+                                            }
+                                        ]
+                                    }
+                                };
+                                if (!hasExtension(props.item, IExtentionType.itemControl)) {
+                                    setItemExtension(props.item, newExtension, props.dispatch)
+                                } else {
+                                    removeItemExtension(props.item, IExtentionType.itemControl, props.dispatch)
+                                }
+                            })}
+                    />
+                </FormField>
+                        </>
                     )}
                     {(isDecimalOrQuantity) && (
                         <FormField>

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -101,7 +101,7 @@ const Question = (props: QuestionProps): JSX.Element => {
     const isSlider = hasExtension(props.item, IExtentionType.itemControl);
     const sliderMinValue = props.item.extension?.find((x) => x.url === IExtentionType.minValue)?.valueInteger;
     const sliderMaxValue = props.item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger;
-    const sliderStepValue = props.item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger;
+    const sliderStepValue = props.item.extension?.find((x) => x.url === IExtentionType.questionnaireSliderStepValue)?.valueInteger;
 
     // Adds instructions for the user
     const instructionType = (): JSX.Element => {

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -205,12 +205,22 @@ const Question = (props: QuestionProps): JSX.Element => {
                                             : IQuestionnaireItemType.decimal;
                                     dispatchUpdateItem(IItemProperty.type, newItemType)
 
-                                    // remove slider extension if toggling to decimal
+                                    // remove slider-related extensions if toggling decimals on, as sliders currently only support integers
                                     if (newItemType === IQuestionnaireItemType.decimal) {
-                                        removeItemExtension(props.item, IExtentionType.itemControl, props.dispatch);
+                                        const extensionsToRemove = [
+                                            IExtentionType.itemControl,
+                                            IExtentionType.questionnaireSliderStepValue,
+                                            IExtentionType.minValue,
+                                            IExtentionType.maxValue
+                                        ]
+                                        removeItemExtension(
+                                            props.item, 
+                                            extensionsToRemove, 
+                                            props.dispatch
+                                        );
                                     }
 
-                                    // remove max decimal places extension if toggling off
+                                    // remove max decimal places extension if toggling decimals off
                                     if (newItemType === IQuestionnaireItemType.integer) {
                                         removeItemExtension(props.item, IExtentionType.maxDecimalPlaces, props.dispatch);
                                     }
@@ -266,9 +276,19 @@ const Question = (props: QuestionProps): JSX.Element => {
                                         }
                                     };
                                     if (!isSlider) {
-                                        setItemExtension(props.item, newExtension, props.dispatch)
+                                        setItemExtension(props.item, newExtension, props.dispatch);
                                     } else {
-                                        removeItemExtension(props.item, IExtentionType.itemControl, props.dispatch)
+                                        const extensionsToRemove = [
+                                            IExtentionType.itemControl,
+                                            IExtentionType.questionnaireSliderStepValue,
+                                            IExtentionType.minValue,
+                                            IExtentionType.maxValue
+                                        ]
+                                        removeItemExtension(
+                                            props.item, 
+                                            extensionsToRemove,
+                                            props.dispatch
+                                        );
                                     }
                                 })}
                         />

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -206,13 +206,18 @@ const Question = (props: QuestionProps): JSX.Element => {
                                             : IQuestionnaireItemType.decimal;
                                     dispatchUpdateItem(IItemProperty.type, newItemType)
 
+                                    // remove slider extension if toggling to decimal
+                                    if (newItemType === IQuestionnaireItemType.decimal) {
+                                        removeItemExtension(props.item, IExtentionType.itemControl, props.dispatch);
+                                    }
+
                                     // remove max decimal places extension if toggling off
                                     if (newItemType === IQuestionnaireItemType.integer) {
                                         removeItemExtension(props.item, IExtentionType.maxDecimalPlaces, props.dispatch);
                                     }
                                 }} />
                             </FormField>
-                            <FormField>
+                            {!(isDecimal || isQuantity) && <FormField>
                                 <SwitchBtn 
                                     label={t('Display as a slider')} 
                                     value={isSlider} 
@@ -236,7 +241,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                                             }
                                         })}
                                 />
-                            </FormField>
+                            </FormField>}
                         </>
                     )}
                     {(isDecimalOrQuantity) && (
@@ -343,7 +348,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                 {respondType()}
             </div>
             <div className="question-addons">
-                {canTypeBeValidated(props.item) && (
+                {canTypeBeValidated(props.item) && !isSlider && (
                     <Accordion title={t('Add validation')}>
                         <ValidationAnswerTypes item={props.item} />
                     </Accordion>

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -39,6 +39,7 @@ import {
     canTypeHaveSublabel,
     getItemDisplayType,
 } from '../../helpers/questionTypeFeatures';
+import SliderSettings from './SliderSettings/SliderSettings';
 
 interface QuestionProps {
     item: QuestionnaireItem;
@@ -99,9 +100,6 @@ const Question = (props: QuestionProps): JSX.Element => {
     const isQuantity = props.item.type === IQuestionnaireItemType.quantity;
     const isDecimalOrQuantity = isDecimal || isQuantity;
     const isSlider = hasExtension(props.item, IExtentionType.itemControl);
-    const sliderMinValue = props.item.extension?.find((x) => x.url === IExtentionType.minValue)?.valueInteger;
-    const sliderMaxValue = props.item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger;
-    const sliderStepValue = props.item.extension?.find((x) => x.url === IExtentionType.questionnaireSliderStepValue)?.valueInteger;
 
     // Adds instructions for the user
     const instructionType = (): JSX.Element => {
@@ -257,6 +255,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                         />
                     )}
                 </FormField>
+                <br />
                 {!isDecimalOrQuantity && 
                     <FormField>
                         <SwitchBtn 
@@ -294,61 +293,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                         />
                     </FormField>
                 }
-                {isSlider && 
-                    <div className="horizontal equal">
-                        <FormField label={t('Slider min value')}>
-                            <input
-                                type="number"
-                                defaultValue={sliderMinValue}
-                                onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                    if (!event.target.value) {
-                                        removeItemExtension(props.item, IExtentionType.minValue, props.dispatch);
-                                    } else {
-                                        const extension = {
-                                            url: IExtentionType.minValue,
-                                            valueInteger: parseInt(event.target.value),
-                                        };
-                                        setItemExtension(props.item, extension, props.dispatch);
-                                    }
-                                }}
-                            ></input>
-                        </FormField>
-                        <FormField label={t('Slider max value')}>
-                            <input
-                                type="number"
-                                defaultValue={sliderMaxValue}
-                                onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                    if (!event.target.value) {
-                                        removeItemExtension(props.item, IExtentionType.maxValue, props.dispatch);
-                                    } else {
-                                        const extension = {
-                                            url: IExtentionType.maxValue,
-                                            valueInteger: parseInt(event.target.value),
-                                        };
-                                        setItemExtension(props.item, extension, props.dispatch);
-                                    }
-                                }}
-                            ></input>
-                        </FormField>
-                        <FormField label={t('Slider step value')}>
-                            <input
-                                type="number"
-                                defaultValue={sliderStepValue}
-                                onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                    if (!event.target.value) {
-                                        removeItemExtension(props.item, IExtentionType.questionnaireSliderStepValue, props.dispatch);
-                                    } else {
-                                        const extension = {
-                                            url: IExtentionType.questionnaireSliderStepValue,
-                                            valueInteger: parseInt(event.target.value),
-                                        };
-                                        setItemExtension(props.item, extension, props.dispatch);
-                                    }
-                                }}
-                            ></input>
-                        </FormField>
-                    </div>
-                }
+                {isSlider && <SliderSettings item={props.item} /> }
                 {/* Sublabel is not currently supported 
                 {canTypeHaveSublabel(props.item) && (
                     <FormField label={t('Sublabel')} isOptional>

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -102,7 +102,7 @@ const Question = (props: QuestionProps): JSX.Element => {
     const isSlider = hasExtension(props.item, IExtentionType.itemControl);
     const sliderMinValue = props.item.extension?.find((x) => x.url === IExtentionType.minValue)?.valueInteger;
     const sliderMaxValue = props.item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger;
-
+    const sliderStepValue = props.item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger;
 
     // Adds instructions for the user
     const instructionType = (): JSX.Element => {
@@ -269,8 +269,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                     )}
                 </FormField>
                 {isSlider && <div className="horizontal equal">
-                    <p>Slider Settings</p>
-                    <FormField label={t('Min value')}>
+                    <FormField label={t('Slider min value')}>
                         <input
                             type="number"
                             defaultValue={sliderMinValue}
@@ -287,7 +286,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                             }}
                         ></input>
                     </FormField>
-                    <FormField label={t('Max value')}>
+                    <FormField label={t('Slider max value')}>
                         <input
                             type="number"
                             defaultValue={sliderMaxValue}
@@ -297,6 +296,23 @@ const Question = (props: QuestionProps): JSX.Element => {
                                 } else {
                                     const extension = {
                                         url: IExtentionType.maxValue,
+                                        valueInteger: parseInt(event.target.value),
+                                    };
+                                    setItemExtension(props.item, extension, props.dispatch);
+                                }
+                            }}
+                        ></input>
+                    </FormField>
+                    <FormField label={t('Slider step value')}>
+                        <input
+                            type="number"
+                            defaultValue={sliderStepValue}
+                            onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                if (!event.target.value) {
+                                    removeItemExtension(props.item, IExtentionType.questionnaireSliderStepValue, props.dispatch);
+                                } else {
+                                    const extension = {
+                                        url: IExtentionType.questionnaireSliderStepValue,
                                         valueInteger: parseInt(event.target.value),
                                     };
                                     setItemExtension(props.item, extension, props.dispatch);

--- a/src/components/Question/SliderSettings/SliderSettings.tsx
+++ b/src/components/Question/SliderSettings/SliderSettings.tsx
@@ -13,9 +13,9 @@ interface SliderSettingsProp {
 const SliderSettings = ({ item }: SliderSettingsProp): JSX.Element => {
     const { t } = useTranslation();
     const { dispatch } = useContext(TreeContext);
-    const [minValue, setMinValue] = useState(item.extension?.find((x) => x.url === 'minValue')?.valueInteger);
-    const [maxValue, setMaxValue] = useState(item.extension?.find((x) => x.url === 'maxValue')?.valueInteger);
-    const [stepValue, setStepValue] = useState(item.extension?.find((x) => x.url === 'questionnaireSliderStepValue')?.valueInteger);
+    const [minValue, setMinValue] = useState(item.extension?.find((x) => x.url === IExtentionType.minValue)?.valueInteger);
+    const [maxValue, setMaxValue] = useState(item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger);
+    const [stepValue, setStepValue] = useState(item.extension?.find((x) => x.url === IExtentionType.questionnaireSliderStepValue)?.valueInteger);
     const [errors, setErrors] = useState({ minValue: false, maxValue: false, stepValue: false });
     const [errorMessage, setErrorMessage] = useState('');
 

--- a/src/components/Question/SliderSettings/SliderSettings.tsx
+++ b/src/components/Question/SliderSettings/SliderSettings.tsx
@@ -1,0 +1,78 @@
+import React, { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TreeContext } from '../../../store/treeStore/treeStore';
+import { removeItemExtension, setItemExtension } from '../../../helpers/extensionHelper';
+import FormField from '../../FormField/FormField';
+import { QuestionnaireItem } from '../../../types/fhir';
+import { IExtentionType, IItemProperty, IQuestionnaireItemType } from '../../../types/IQuestionnareItemType';
+
+
+interface SliderSettingsProp {
+    item: QuestionnaireItem;
+}
+
+const SliderSettings = ({ item }: SliderSettingsProp): JSX.Element => {
+    const { t } = useTranslation();
+    const { dispatch } = useContext(TreeContext);
+    const sliderMinValue = item.extension?.find((x) => x.url === IExtentionType.minValue)?.valueInteger;
+    const sliderMaxValue = item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger;
+    const sliderStepValue = item.extension?.find((x) => x.url === IExtentionType.questionnaireSliderStepValue)?.valueInteger;
+
+    return (
+        <div className="horizontal equal">
+            <FormField label={t('Slider min value')}>
+                <input
+                    type="number"
+                    defaultValue={sliderMinValue}
+                    onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                        if (!event.target.value) {
+                            removeItemExtension(item, IExtentionType.minValue, dispatch);
+                        } else {
+                            const extension = {
+                                url: IExtentionType.minValue,
+                                valueInteger: parseInt(event.target.value),
+                            };
+                            setItemExtension(item, extension, dispatch);
+                        }
+                    }}
+                ></input>
+            </FormField>
+            <FormField label={t('Slider max value')}>
+                <input
+                    type="number"
+                    defaultValue={sliderMaxValue}
+                    onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                        if (!event.target.value) {
+                            removeItemExtension(item, IExtentionType.maxValue, dispatch);
+                        } else {
+                            const extension = {
+                                url: IExtentionType.maxValue,
+                                valueInteger: parseInt(event.target.value),
+                            };
+                            setItemExtension(item, extension, dispatch);
+                        }
+                    }}
+                ></input>
+            </FormField>
+            <FormField label={t('Slider step value')}>
+                <input
+                    type="number"
+                    defaultValue={sliderStepValue}
+                    onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                        if (!event.target.value) {
+                            removeItemExtension(item, IExtentionType.questionnaireSliderStepValue, dispatch);
+                        } else {
+                            const extension = {
+                                url: IExtentionType.questionnaireSliderStepValue,
+                                valueInteger: parseInt(event.target.value),
+                            };
+                            setItemExtension(item, extension, dispatch);
+                        }
+                    }}
+                ></input>
+            </FormField>
+        </div>
+    )
+}
+
+export default SliderSettings;

--- a/src/components/Question/SliderSettings/SliderSettings.tsx
+++ b/src/components/Question/SliderSettings/SliderSettings.tsx
@@ -1,11 +1,9 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TreeContext } from '../../../store/treeStore/treeStore';
 import { removeItemExtension, setItemExtension } from '../../../helpers/extensionHelper';
 import FormField from '../../FormField/FormField';
 import { QuestionnaireItem } from '../../../types/fhir';
-import { IExtentionType, IItemProperty, IQuestionnaireItemType } from '../../../types/IQuestionnareItemType';
-
 
 interface SliderSettingsProp {
     item: QuestionnaireItem;
@@ -14,64 +12,100 @@ interface SliderSettingsProp {
 const SliderSettings = ({ item }: SliderSettingsProp): JSX.Element => {
     const { t } = useTranslation();
     const { dispatch } = useContext(TreeContext);
-    const sliderMinValue = item.extension?.find((x) => x.url === IExtentionType.minValue)?.valueInteger;
-    const sliderMaxValue = item.extension?.find((x) => x.url === IExtentionType.maxValue)?.valueInteger;
-    const sliderStepValue = item.extension?.find((x) => x.url === IExtentionType.questionnaireSliderStepValue)?.valueInteger;
+    const [minValue, setMinValue] = useState(item.extension?.find((x) => x.url === 'minValue')?.valueInteger);
+    const [maxValue, setMaxValue] = useState(item.extension?.find((x) => x.url === 'maxValue')?.valueInteger);
+    const [stepValue, setStepValue] = useState(item.extension?.find((x) => x.url === 'questionnaireSliderStepValue')?.valueInteger);
+    const [error, setError] = useState('');
+
+    const validate = () => {
+        if (minValue == null || maxValue == null) {
+            setError(t('Both min and max values must be filled in.'));
+            return false;
+        }
+        if (stepValue == null || (maxValue - minValue) % stepValue !== 0) {
+            setError(t('Step value must be divisible by the difference between max and min values.'));
+            return false;
+        }
+        setError('');
+        return true;
+    };
+
+    const handleMinValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const value = parseInt(event.target.value);
+        setMinValue(value);
+        if (!event.target.value) {
+            removeItemExtension(item, 'minValue', dispatch);
+        } else {
+            const extension = {
+                url: 'minValue',
+                valueInteger: value,
+            };
+            setItemExtension(item, extension, dispatch);
+        }
+    };
+
+    const handleMaxValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const value = parseInt(event.target.value);
+        setMaxValue(value);
+        if (!event.target.value) {
+            removeItemExtension(item, 'maxValue', dispatch);
+        } else {
+            const extension = {
+                url: 'maxValue',
+                valueInteger: value,
+            };
+            setItemExtension(item, extension, dispatch);
+        }
+    };
+
+    const handleStepValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const value = parseInt(event.target.value);
+        setStepValue(value);
+        if (!event.target.value) {
+            removeItemExtension(item, 'questionnaireSliderStepValue', dispatch);
+        } else {
+            const extension = {
+                url: 'questionnaireSliderStepValue',
+                valueInteger: value,
+            };
+            setItemExtension(item, extension, dispatch);
+        }
+    };
+
+    const handleBlur = () => {
+        validate();
+    };
 
     return (
+        <>
         <div className="horizontal equal">
             <FormField label={t('Slider min value')}>
                 <input
                     type="number"
-                    defaultValue={sliderMinValue}
-                    onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                        if (!event.target.value) {
-                            removeItemExtension(item, IExtentionType.minValue, dispatch);
-                        } else {
-                            const extension = {
-                                url: IExtentionType.minValue,
-                                valueInteger: parseInt(event.target.value),
-                            };
-                            setItemExtension(item, extension, dispatch);
-                        }
-                    }}
+                    value={minValue || ''}
+                    onBlur={handleBlur}
+                    onChange={handleMinValueChange}
                 ></input>
             </FormField>
             <FormField label={t('Slider max value')}>
                 <input
                     type="number"
-                    defaultValue={sliderMaxValue}
-                    onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                        if (!event.target.value) {
-                            removeItemExtension(item, IExtentionType.maxValue, dispatch);
-                        } else {
-                            const extension = {
-                                url: IExtentionType.maxValue,
-                                valueInteger: parseInt(event.target.value),
-                            };
-                            setItemExtension(item, extension, dispatch);
-                        }
-                    }}
+                    value={maxValue || ''}
+                    onBlur={handleBlur}
+                    onChange={handleMaxValueChange}
                 ></input>
             </FormField>
             <FormField label={t('Slider step value')}>
                 <input
                     type="number"
-                    defaultValue={sliderStepValue}
-                    onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
-                        if (!event.target.value) {
-                            removeItemExtension(item, IExtentionType.questionnaireSliderStepValue, dispatch);
-                        } else {
-                            const extension = {
-                                url: IExtentionType.questionnaireSliderStepValue,
-                                valueInteger: parseInt(event.target.value),
-                            };
-                            setItemExtension(item, extension, dispatch);
-                        }
-                    }}
+                    value={stepValue || ''}
+                    onBlur={handleBlur}
+                    onChange={handleStepValueChange}
                 ></input>
             </FormField>
         </div>
+        {error && <div style={{ color: 'red' }}>{error}</div>}
+        </>
     )
 }
 

--- a/src/components/Question/SliderSettings/SliderSettings.tsx
+++ b/src/components/Question/SliderSettings/SliderSettings.tsx
@@ -4,6 +4,7 @@ import { TreeContext } from '../../../store/treeStore/treeStore';
 import { removeItemExtension, setItemExtension } from '../../../helpers/extensionHelper';
 import FormField from '../../FormField/FormField';
 import { QuestionnaireItem } from '../../../types/fhir';
+import { IExtentionType } from '../../../types/IQuestionnareItemType';
 
 interface SliderSettingsProp {
     item: QuestionnaireItem;
@@ -59,7 +60,7 @@ const SliderSettings = ({ item }: SliderSettingsProp): JSX.Element => {
             const value = parseInt(event.target.value);
             setMinValue(value);
             const extension = {
-                url: 'minValue',
+                url: IExtentionType.minValue,
                 valueInteger: value,
             };
             setItemExtension(item, extension, dispatch);
@@ -75,7 +76,7 @@ const SliderSettings = ({ item }: SliderSettingsProp): JSX.Element => {
             const value = parseInt(event.target.value);
             setMaxValue(value);
             const extension = {
-                url: 'maxValue',
+                url: IExtentionType.maxValue,
                 valueInteger: value,
             };
             setItemExtension(item, extension, dispatch);
@@ -83,13 +84,14 @@ const SliderSettings = ({ item }: SliderSettingsProp): JSX.Element => {
     };
 
     const handleStepValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const value = parseInt(event.target.value, 10);
-        setStepValue(value);
         if (!event.target.value) {
+            setStepValue(undefined);
             removeItemExtension(item, 'questionnaireSliderStepValue', dispatch);
         } else {
+            const value = parseInt(event.target.value);
+            setStepValue(value);
             const extension = {
-                url: 'questionnaireSliderStepValue',
+                url: IExtentionType.questionnaireSliderStepValue,
                 valueInteger: value,
             };
             setItemExtension(item, extension, dispatch);

--- a/src/helpers/itemControl.ts
+++ b/src/helpers/itemControl.ts
@@ -16,6 +16,7 @@ export enum ItemControlType {
     year = 'year',
     receiverComponent = 'receiver-component',
     dynamic = 'dynamic',
+    slider = 'slider'
 }
 
 export const createItemControlExtension = (itemControlType: ItemControlType): Extension => {
@@ -85,6 +86,10 @@ export const isItemControlSidebar = (item: QuestionnaireItem): boolean => {
 
 export const isItemControlInline = (item?: QuestionnaireItem): boolean => {
     return item?.type === IQuestionnaireItemType.text && getItemControlType(item) === ItemControlType.inline;
+};
+
+export const isItemControlSlider = (item?: QuestionnaireItem): boolean => {
+    return getItemControlType(item) === ItemControlType.slider;
 };
 
 export const getHelpText = (item: QuestionnaireItem): string => {

--- a/src/types/IQuestionnareItemType.ts
+++ b/src/types/IQuestionnareItemType.ts
@@ -100,6 +100,7 @@ export enum IExtentionType {
     optionReference = 'http://ehelse.no/fhir/StructureDefinition/sdf-optionReference',
     presentationbuttons = 'http://helsenorge.no/fhir/StructureDefinition/sdf-presentationbuttons',
     questionnaireUnit = 'http://hl7.org/fhir/StructureDefinition/questionnaire-unit',
+    questionnaireSliderStepValue = 'http://hl7.org/fhir/StructureDefinition/questionnaire-sliderStepValue',
     regEx = 'http://hl7.org/fhir/StructureDefinition/regex',
     repeatstext = 'http://ehelse.no/fhir/StructureDefinition/repeatstext',
     maxOccurs = 'http://hl7.org/fhir/StructureDefinition/questionnaire-maxOccurs',


### PR DESCRIPTION
# Allow numerical input using a slider

## :recycle: Current situation & Problem
Currently our JSON only supports numerical answers that are entered in a field. However, in many cases, we may want to use a slider as the control. The HL7 SDC Implementation Guide supports the use of sliders via the [item-control](http://hl7.org/fhir/R4/extension-questionnaire-itemcontrol.html) extension. The ResearchKitOnFHIR package also [implements this extension](https://github.com/StanfordBDHG/ResearchKitOnFHIR/pull/63) 

## :gear: Release Notes 
- Adds a toggle button to allow the user to display a number question as a slider, which adds the item-control extension.
- Adds fields for the user to define the minimum, maximum, and step values of the slider.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
