### PR TITLE
Minor fixes for extensions

### DIFF
--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -256,7 +256,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                     )}
                 </FormField>
                 <br />
-                {!isDecimalOrQuantity && 
+                {isNumber && !isDecimalOrQuantity &&
                     <FormField>
                         <SwitchBtn 
                             label={t('Display as a slider')} 

--- a/src/types/IQuestionnareItemType.ts
+++ b/src/types/IQuestionnareItemType.ts
@@ -105,7 +105,7 @@ export enum IExtentionType {
     repeatstext = 'http://ehelse.no/fhir/StructureDefinition/repeatstext',
     maxOccurs = 'http://hl7.org/fhir/StructureDefinition/questionnaire-maxOccurs',
     minOccurs = 'http://hl7.org/fhir/StructureDefinition/questionnaire-minOccurs',
-    validationtext = 'http://ehelse.no/fhir/StructureDefinition/validationtext',
+    validationtext = 'http://biodesign.stanford.edu/fhir/StructureDefinition/validationtext',
     navigator = 'http://helsenorge.no/fhir/StructureDefinition/sdf-questionnaire-navgiator-state',
     navigatorCodeSystem = 'http://helsenorge.no/fhir/CodeSystem/sdf-questionnaire-navigator-state ',
     fhirPathMaxValue = 'http://ehelse.no/fhir/StructureDefinition/sdf-maxvalue',


### PR DESCRIPTION
# Minor fixes for extensions 

## :recycle: Current situation & Problem
- `validationtext` extension URI used by Phoenix is not recognized by ResearchKitOnFHIR.
- `Display as a slider` option appears on inappropriate answer types.

## :gear: Release Notes 
- Fixes the minor issues listed above.

## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
