### PR TITLE
Support `required` flag for group items

### DIFF
--- a/src/helpers/orphanValidation.ts
+++ b/src/helpers/orphanValidation.ts
@@ -42,8 +42,7 @@ const validateUniqueLinkId = (
 const validateRequiredItem = (t: TFunction<'translation'>, qItem: QuestionnaireItem): ValidationErrors[] => {
     const returnErrors: ValidationErrors[] = [];
     if (
-        (qItem.type === IQuestionnaireItemType.group ||
-            qItem.type === IQuestionnaireItemType.display ||
+        (qItem.type === IQuestionnaireItemType.display ||
             isItemControlInline(qItem) ||
             isItemControlHighlight(qItem) ||
             isItemControlHelp(qItem) ||

--- a/src/helpers/questionTypeFeatures.ts
+++ b/src/helpers/questionTypeFeatures.ts
@@ -126,7 +126,6 @@ export const canTypeHaveSublabel = (item: QuestionnaireItem): boolean => {
 
 export const canTypeBeRequired = (item: QuestionnaireItem): boolean => {
     return (
-        item.type !== IQuestionnaireItemType.group &&
         item.type !== IQuestionnaireItemType.display &&
         !isItemControlInline(item) &&
         !isItemControlHighlight(item) &&


### PR DESCRIPTION
# Support `required` flag for group items

## :recycle: Current situation & Problem
Relates to [this issue](https://github.com/StanfordBDHG/phoenix/issues/44) where the required flag for the Group item couldn't be changed using the survey builder.


## :gear: Release Notes 
- Group items now allow the `required` field to be toggled, similar to other types such as the text field as described in [this issue](https://github.com/StanfordBDHG/phoenix/issues/44).


## :white_check_mark: Testing
![image](https://github.com/user-attachments/assets/6203ea73-8d78-41ed-8564-4fad2f3ca6ab)



### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
