### PR TITLE
Fix compile warnings

### DIFF
--- a/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
+++ b/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
@@ -263,7 +263,7 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
                         <div className="msg-error" aria-live="polite">
                             {`${t('LinkId is already in use')} `}
                             <button onClick={resetLinkId}>
-                                <img src={UndoIcon} height={16} />
+                                <img src={UndoIcon}  alt="Undo Button" height={16} />
                                 {` ${t('Sett tilbake til opprinnelig verdi')}`}
                             </button>
                         </div>

--- a/src/components/Languages/Translation/TranslateSettings.tsx
+++ b/src/components/Languages/Translation/TranslateSettings.tsx
@@ -35,7 +35,7 @@ const TranslateSettings = ({
         <div>
             <div className="translation-section-header">{t('Questionnaire settings')}</div>
             {Object.values(translatableSettings).map((extensionToTranslate) => {
-                if (!extensionToTranslate) return;
+                if (!extensionToTranslate) return [];
 
                 const mainExtension = (extensions || []).find((e) => e.url === extensionToTranslate.extension);
                 let baseValue;

--- a/src/components/Metadata/MetadataEditor.tsx
+++ b/src/components/Metadata/MetadataEditor.tsx
@@ -15,7 +15,6 @@ import { TreeContext } from '../../store/treeStore/treeStore';
 import { updateQuestionnaireMetadataAction } from '../../store/treeStore/treeActions';
 import RadioBtn from '../RadioBtn/RadioBtn';
 import InputField from '../InputField/inputField';
-import { UseContextSystem } from '../../types/IQuestionnareItemType';
 
 const MetadataEditor = (): JSX.Element => {
     const { t } = useTranslation();
@@ -29,17 +28,6 @@ const MetadataEditor = (): JSX.Element => {
         value: string | Meta | Extension[] | ContactDetail[] | UsageContext[],
     ) => {
         dispatch(updateQuestionnaireMetadataAction(propName, value));
-    };
-
-    const getUseContextSystem = (): string => {
-        const system =
-            qMetadata.useContext &&
-            qMetadata.useContext.length > 0 &&
-            qMetadata.useContext[0].valueCodeableConcept?.coding &&
-            qMetadata.useContext[0].valueCodeableConcept.coding.length > 0 &&
-            qMetadata.useContext[0].valueCodeableConcept.coding[0].system;
-
-        return system || UseContextSystem.helsetjeneste_full;
     };
 
     return (

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -116,7 +116,7 @@ const Navbar = ({
         <>
             <header ref={navBarRef}>
                 <div className="pull-left form-title">
-                    <h1><IconBtn type="x" title={t('Close')} onClick={() => {close()}} /><a className="survey-title-button" onClick={toggleFormDetails}>{title || 'Phoenix Survey Builder'}</a></h1>
+                    <h1><IconBtn type="x" title={t('Close')} onClick={() => {close()}} /><a className="survey-title-button" href="#!" onClick={toggleFormDetails}>{title || 'Phoenix Survey Builder'}</a></h1>
                 </div>
 
                 <div className="pull-right">

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -15,7 +15,7 @@ import { IExtentionType, IItemProperty, IQuestionnaireItemType } from '../../typ
 import { updateItemAction } from '../../store/treeStore/treeActions';
 import { isRecipientList } from '../../helpers/QuestionHelper';
 import { createMarkdownExtension, removeItemExtension, setItemExtension, hasExtension } from '../../helpers/extensionHelper';
-import { isItemControlInline, isItemControlReceiverComponent, isItemControlHighlight } from '../../helpers/itemControl';
+import { isItemControlInline, isItemControlHighlight } from '../../helpers/itemControl';
 
 import Accordion from '../Accordion/Accordion';
 import { ActionType } from '../../store/treeStore/treeStore';
@@ -36,7 +36,6 @@ import { ValidationErrors } from '../../helpers/orphanValidation';
 import {
     canTypeBeRequired,
     canTypeBeValidated,
-    canTypeHaveSublabel,
     getItemDisplayType,
 } from '../../helpers/questionTypeFeatures';
 import SliderSettings from './SliderSettings/SliderSettings';
@@ -54,7 +53,7 @@ interface QuestionProps {
 
 const Question = (props: QuestionProps): JSX.Element => {
     const { t } = useTranslation();
-    const [isMarkdownActivated, setIsMarkdownActivated] = React.useState<boolean>(!!props.item._text);
+    const [isMarkdownActivated] = React.useState<boolean>(!!props.item._text);
     const codeElements = props.item.code ? `(${props.item.code.length})` : '(0)';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const removeMd = require('remove-markdown');
@@ -73,10 +72,6 @@ const Question = (props: QuestionProps): JSX.Element => {
                 props.item._text?.extension?.find((x) => x.url === IExtentionType.markdown)?.valueMarkdown || '';
         }
         return labelText || props.item.text || '';
-    };
-
-    const getSublabelText = (): string => {
-        return props.item.extension?.find((x) => x.url === IExtentionType.sublabel)?.valueMarkdown || '';
     };
 
     const convertToPlaintext = (stringToBeConverted: string) => {

--- a/src/components/Question/QuestionType/Choice.tsx
+++ b/src/components/Question/QuestionType/Choice.tsx
@@ -21,7 +21,7 @@ import SwitchBtn from '../../SwitchBtn/SwitchBtn';
 import { createUriUUID } from '../../../helpers/uriHelper';
 import DraggableAnswerOptions from '../../AnswerOption/DraggableAnswerOptions';
 import PredefinedValueSets from './PredefinedValueSets';
-import { ItemControlType, isItemControlCheckbox, isItemControlDropDown } from '../../../helpers/itemControl';
+import { ItemControlType, isItemControlCheckbox } from '../../../helpers/itemControl';
 import { checkboxExtension } from '../../../helpers/QuestionHelper';
 
 type Props = {


### PR DESCRIPTION
# Fixed several compile warnings

## :recycle: Current situation & Problem
Fixed the following compile warnings to maintain a cleaner compile window.
```
src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
  Line 266:33:  img elements must have an alt prop, either with meaningful text, or an empty string for decorative images  jsx-a11y/alt-text

src/components/Languages/Translation/TranslateSettings.tsx
  Line 38:44:  Array.prototype.map() expects a return value from arrow function  array-callback-return

src/components/Metadata/MetadataEditor.tsx
  Line 34:11:  'getUseContextSystem' is assigned a value but never used  @typescript-eslint/no-unused-vars

src/components/Navbar/Navbar.tsx
  Line 119:90:  The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid

src/components/Question/Question.tsx
  Line 18:31:  'isItemControlReceiverComponent' is defined but never used   @typescript-eslint/no-unused-vars
  Line 39:5:   'canTypeHaveSublabel' is defined but never used              @typescript-eslint/no-unused-vars
  Line 57:33:  'setIsMarkdownActivated' is assigned a value but never used  @typescript-eslint/no-unused-vars
  Line 78:11:  'getSublabelText' is assigned a value but never used
@typescript-eslint/no-unused-vars

src/components/Question/QuestionType/Choice.tsx
  Line 24:50:  'isItemControlDropDown' is defined but never used  @typescript-eslint/no-unused-vars

```


## :white_check_mark: Testing
Ensured that the compile warnings are gone.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
