### PR TITLE
Form validation update

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -8,7 +8,7 @@ import JSONView from '../JSONView/JSONView';
 import PredefinedValueSetModal from '../PredefinedValueSetModal/PredefinedValueSetModal';
 import ImportValueSet from '../ImportValueSet/ImportValueSet';
 import { saveAction } from '../../store/treeStore/treeActions';
-import { validateOrphanedElements, validateTranslations, ValidationErrors } from '../../helpers/orphanValidation';
+import { validateTranslations, ValidationErrors } from '../../helpers/orphanValidation';
 import { ValidationErrorsModal } from '../ValidationErrorsModal/validationErrorsModal';
 import { useTranslation } from 'react-i18next';
 import IconBtn from '../IconBtn/IconBtn';
@@ -16,7 +16,6 @@ import MoreIcon from '../../images/icons/ellipsis-horizontal-outline.svg';
 
 type Props = {
     showFormFiller: () => void;
-    setValidationErrors: (errors: ValidationErrors[]) => void;
     validationErrors: ValidationErrors[];
     translationErrors: ValidationErrors[];
     setTranslationErrors: (errors: ValidationErrors[]) => void;
@@ -32,7 +31,6 @@ enum MenuItem {
 }
 
 const Navbar = ({
-    setValidationErrors,
     validationErrors,
     translationErrors,
     setTranslationErrors,
@@ -130,13 +128,22 @@ const Navbar = ({
                     )}
                     <Btn title={t('Edit Metadata')} onClick={() => toggleFormDetails()} />
                     <Btn title={t('Preview')} onClick={() => {
-                        // validate the FHIR and then show the JSON
-                        setValidationErrors(
-                            validateOrphanedElements(t, state.qOrder, state.qItems, state.qContained || []),
-                        );
+                        // show the JSON
                         setShowJSONView(!showJSONView);
                     }} />
-                    <Btn title={t('Download')} onClick={() => exportToJsonAndDownload()} />
+                    <Btn title={t('Download')} onClick={() => {
+                            setTranslationErrors(
+                                validateTranslations(t, state.qOrder, state.qItems, state.qAdditionalLanguages),
+                            );
+                            if(validationErrors.length > 0 || translationErrors.length > 0)
+                            {
+                                setShowValidationErrors(true);
+                            }
+                            else
+                            {
+                                exportToJsonAndDownload();
+                            }
+                        }} />
                     <div
                         className="more-menu"
                         tabIndex={0}
@@ -155,9 +162,6 @@ const Navbar = ({
                         <Btn
                             title={t('Validate')}
                             onClick={() => {
-                                setValidationErrors(
-                                    validateOrphanedElements(t, state.qOrder, state.qItems, state.qContained || []),
-                                );
                                 setTranslationErrors(
                                     validateTranslations(t, state.qOrder, state.qItems, state.qAdditionalLanguages),
                                 );

--- a/src/views/FormBuilder.tsx
+++ b/src/views/FormBuilder.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TreeContext } from '../store/treeStore/treeStore';
 import AnchorMenu from '../components/AnchorMenu/AnchorMenu';
@@ -6,7 +6,7 @@ import Navbar from '../components/Navbar/Navbar';
 import QuestionDrawer from '../components/QuestionDrawer/QuestionDrawer';
 import Modal from '../components/Modal/Modal'
 import './FormBuilder.css';
-import { ValidationErrors } from '../helpers/orphanValidation';
+import {validateOrphanedElements, ValidationErrors } from '../helpers/orphanValidation';
 import TranslationModal from '../components/Languages/Translation/TranslationModal';
 import MetadataEditor from '../components/Metadata/MetadataEditor';
 import SurveySetup from './SurveySetup'
@@ -20,7 +20,6 @@ const FormBuilder = (props: FormBuilderProps): JSX.Element => {
     const { state, dispatch } = useContext(TreeContext);
     const [showFormDetails, setShowFormDetails] = useState(false);
     const [showPreview, setShowPreview] = useState(false);
-    const [validationErrors, setValidationErrors] = useState<Array<ValidationErrors>>([]);
     const [translationErrors, setTranslationErrors] = useState<Array<ValidationErrors>>([]);
     const [translateLang, setTranslateLang] = useState('');
 
@@ -29,12 +28,16 @@ const FormBuilder = (props: FormBuilderProps): JSX.Element => {
         setShowFormDetails(!showFormDetails);
     }, [showFormDetails]);
 
+    const recomputeValidationErrors = useMemo(() => 
+        validateOrphanedElements(t, state.qOrder, state.qItems, state.qContained || []),
+        [t, state.qOrder, state.qItems, state.qContained] // Dependencies array
+    );
+
     return (
         <>
             <Navbar
                 showFormFiller={() => setShowPreview(!showPreview)}
-                validationErrors={validationErrors}
-                setValidationErrors={setValidationErrors}
+                validationErrors={recomputeValidationErrors}
                 translationErrors={translationErrors}
                 setTranslationErrors={setTranslationErrors}
                 toggleFormDetails={toggleFormDetails}
@@ -48,7 +51,7 @@ const FormBuilder = (props: FormBuilderProps): JSX.Element => {
                     qOrder={state.qOrder}
                     qItems={state.qItems}
                     qCurrentItem={state.qCurrentItem}
-                    validationErrors={validationErrors}
+                    validationErrors={recomputeValidationErrors}
                 />
                 ) : (
                     <SurveySetup />
@@ -67,7 +70,7 @@ const FormBuilder = (props: FormBuilderProps): JSX.Element => {
                         <MetadataEditor />
                     </Modal>
                 }
-                <QuestionDrawer validationErrors={validationErrors} />
+                <QuestionDrawer validationErrors={recomputeValidationErrors} />
             </div>
         </>
     );


### PR DESCRIPTION
# Automatically validate the form when a change is detected.

## :recycle: Current situation & Problem
With the current UX flow, the user is required to find and press the "Validate" button to validate the form. There are a few problem with this flow:
- Problems remaining undetected until later and take longer to revisit and fix. 
- No real-time feedback for changes to ensure errors are properly addressed. 
- Additional button clicks and workflow steps to ensure a valid form.


## :gear: Release Notes 
The validation checks now run automatically whenever a change to the form is detected. Feedback is provided immediately for when validation checks fail.
The download option only allows downloading the form if the form is valid, otherwise displays an error.


## :books: Documentation
Now presents feedback any time a change is made to an item that will cause a validation error.
A red outline appears on items in the form builder whenever a validation check fails.
Resolving an error immediately makes the error go away.
The "Validate" check only checks for translation errors.
The download button only allows downloading if there are no errors in the FHIR otherwise it displays an error box.

Performance:
Added caching to reduce the number of times the validation is run if the values remain unchanged to improve performance.


## :white_check_mark: Testing
### Auto validation on change
![2024-08-28 14-22-48](https://github.com/user-attachments/assets/6a328b22-1d2b-4577-847a-fb957bb9c8e2)



### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
