### PR TITLE
fix incorrect `enableWhenBehavior`, some UI improvements

### DIFF
--- a/src/components/Drawer/Drawer.css
+++ b/src/components/Drawer/Drawer.css
@@ -1,6 +1,6 @@
 .drawer {
     display: block;
-    height: 100%;
+    height: calc(100% - 64px);
     background: white;
     position: fixed;
     top: 64px;

--- a/src/components/EnableWhen/EnableBehavior.tsx
+++ b/src/components/EnableWhen/EnableBehavior.tsx
@@ -21,16 +21,13 @@ const EnableBehavior = ({ currentItem, dispatchUpdateItemEnableBehavior }: Props
                         ? QuestionnaireItemEnableBehaviorCodes.ALL
                         : QuestionnaireItemEnableBehaviorCodes.ANY
                 }
-                options={[
-                    {
-                        code: QuestionnaireItemEnableBehaviorCodes.ANY,
-                        display: t('At least one condition must be fulfilled'),
-                    },
-                    {
-                        code: QuestionnaireItemEnableBehaviorCodes.ALL,
-                        display: t('All conditions must be fulfilled'),
-                    },
-                ]}
+                options={[{
+                    code: QuestionnaireItemEnableBehaviorCodes.ALL,
+                    display: t('All conditions must be fulfilled')
+                }, {
+                    code: QuestionnaireItemEnableBehaviorCodes.ANY,
+                    display: t('At least one condition must be fulfilled')
+                }]}
                 name={`ew-behavior-${currentItem.linkId}`}
             />
         </div>

--- a/src/components/EnableWhen/EnableWhen.tsx
+++ b/src/components/EnableWhen/EnableWhen.tsx
@@ -64,7 +64,13 @@ const EnableWhen = ({
 
     return (
         <div>
-            <p>{t('Set a condition for displaying this question:')}</p>
+            <p>{t('Define which conditions must be fulfilled for enabling this question. If no conditions are defined, the question is always enabled.')}</p>
+            {enableWhen.length > 1 && (
+                <EnableBehavior
+                    currentItem={getItem(linkId)}
+                    dispatchUpdateItemEnableBehavior={dispatchUpdateItemEnableBehavior}
+                />
+            )}
             {enableWhen.map((x, index) => {
                 const conditionItem = getItem(x.question);
                 const hasValidationError = itemValidationErrors.some(
@@ -158,12 +164,6 @@ const EnableWhen = ({
                 icon="ion-plus-round"
                 title={t('Add a condition')}
             />
-            {enableWhen.length > 1 && (
-                <EnableBehavior
-                    currentItem={getItem(linkId)}
-                    dispatchUpdateItemEnableBehavior={dispatchUpdateItemEnableBehavior}
-                />
-            )}
             {enableWhen.length > 0 && (
                 <EnableWhenInfoBox
                     getItem={getItem}

--- a/src/components/EnableWhen/EnableWhen.tsx
+++ b/src/components/EnableWhen/EnableWhen.tsx
@@ -64,7 +64,7 @@ const EnableWhen = ({
 
     return (
         <div>
-            <p>{t('Define which conditions must be fulfilled for enabling this question. If no conditions are defined, the question is always enabled.')}</p>
+            <p>{t('Define which conditions must be fulfilled for enabling this question.\nIf no conditions are defined, the question is always enabled.')}</p>
             {enableWhen.length > 1 && (
                 <EnableBehavior
                     currentItem={getItem(linkId)}

--- a/src/components/Question/Question.css
+++ b/src/components/Question/Question.css
@@ -1,6 +1,5 @@
 .question {
     background: white;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     border-radius: 8px;
     margin-bottom: 24px;
 }


### PR DESCRIPTION
# fix incorrect `enableWhenBehavior`, some UI improvements

## :recycle: Current situation & Problem
- The editor currently does not add an `enableWhenBehavior` field to questions with multiple `enableWhen` conditions, even though [the FHIR spec requires this](https://www.hl7.org/fhir/questionnaire-definitions.html#Questionnaire.item).
  - Additionally, the UI would in this case say that the `any` behaviour was selected (even though it wasn't; there was no selection).
  - This is kinda bad, since ResearchKitOnFHIR defaults a missing `enableWhenBehavior` to `all`, which is of course the opposite of what you'd expect when the web UI said "any".
  - (See https://github.com/StanfordBDHG/phoenix/issues/64 for a full explanation.)
- The overlay displayed when editing questions always cuts off the bottom 64 pixels of the question editor, which makes it difficult to reach the buttons down there, or to even see that they exist


## :gear: Release Notes 
- fix incorrect default `enableWhenBehavior`
- improve question editing UI


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

fixes https://github.com/StanfordBDHG/phoenix/issues/64
