### PR TITLE
Add page control to all groups

### DIFF
--- a/src/helpers/itemControl.ts
+++ b/src/helpers/itemControl.ts
@@ -16,7 +16,8 @@ export enum ItemControlType {
     year = 'year',
     receiverComponent = 'receiver-component',
     dynamic = 'dynamic',
-    slider = 'slider'
+    slider = 'slider',
+    page = 'page'
 }
 
 export const createItemControlExtension = (itemControlType: ItemControlType): Extension => {
@@ -90,6 +91,10 @@ export const isItemControlInline = (item?: QuestionnaireItem): boolean => {
 
 export const isItemControlSlider = (item?: QuestionnaireItem): boolean => {
     return getItemControlType(item) === ItemControlType.slider;
+};
+
+export const isItemControlPage = (item?: QuestionnaireItem): boolean => {
+    return getItemControlType(item) === ItemControlType.page;
 };
 
 export const getHelpText = (item: QuestionnaireItem): string => {

--- a/src/helpers/questionTypeFeatures.ts
+++ b/src/helpers/questionTypeFeatures.ts
@@ -41,6 +41,8 @@ export const getInitialItemConfig = (
     if (questionType === IQuestionnaireItemType.group) {
         newQuestionnaireItem.type = IQuestionnaireItemType.group;
         const pageExtension = createItemControlExtension(ItemControlType.page);
+        // Adds additional fields as included in the example shown in the Android FHIR docs: 
+        // https://google.github.io/android-fhir/use/SDCL/Author-questionnaires/#questionnaire-basics
         if (pageExtension.valueCodeableConcept) {
             pageExtension.valueCodeableConcept.text = 'Page';
             if (pageExtension.valueCodeableConcept.coding && pageExtension.valueCodeableConcept.coding[0]) {

--- a/src/helpers/questionTypeFeatures.ts
+++ b/src/helpers/questionTypeFeatures.ts
@@ -40,6 +40,7 @@ export const getInitialItemConfig = (
     } as QuestionnaireItem;
     if (questionType === IQuestionnaireItemType.group) {
         newQuestionnaireItem.type = IQuestionnaireItemType.group;
+        // Groups are paginated by default
         const pageExtension = createItemControlExtension(ItemControlType.page);
         // Adds additional fields as included in the example shown in the Android FHIR docs: 
         // https://google.github.io/android-fhir/use/SDCL/Author-questionnaires/#questionnaire-basics

--- a/src/helpers/questionTypeFeatures.ts
+++ b/src/helpers/questionTypeFeatures.ts
@@ -40,6 +40,14 @@ export const getInitialItemConfig = (
     } as QuestionnaireItem;
     if (questionType === IQuestionnaireItemType.group) {
         newQuestionnaireItem.type = IQuestionnaireItemType.group;
+        const pageExtension = createItemControlExtension(ItemControlType.page);
+        if (pageExtension.valueCodeableConcept) {
+            pageExtension.valueCodeableConcept.text = 'Page';
+            if (pageExtension.valueCodeableConcept.coding && pageExtension.valueCodeableConcept.coding[0]) {
+                pageExtension.valueCodeableConcept.coding[0].display = 'Page';
+            }
+        }
+        newQuestionnaireItem.extension?.push(pageExtension);
     } else if (questionType === IQuestionnaireItemType.attachment) {
         const maxFileSizeExtension = {
             url: IExtentionType.maxSize,


### PR DESCRIPTION
# Add page control to all groups

## :recycle: Current situation & Problem
[ResearchKitOnFHIR](https://github.com/StanfordBDHG/ResearchKitOnFHIR) renders `group` items in a paginated fashion, where each `group` is a single page. However, [Android FHIR](https://github.com/google/android-fhir) does not interpret the `group` item in this manner without the `page` item control extension being applied (see more detail in the [Android FHIR docs](https://google.github.io/android-fhir/use/SDCL/Author-questionnaires/#questionnaire-basics)).

> [!NOTE]
> `Group` by itself in the FHIR standard does not imply that the questions in the group should be paginated. However, because this is the only option for displaying groups of questions in [ResearchKit](https://github.com/ResearchKit/ResearchKit), we will keep it as the default behavior on both mobile platforms.

## :gear: Release Notes 
We apply the `page` item control extension to the JSON when a `group` is created. This does not have any breaking change when questionnaires are rendered via [ResearchKitOnFHIR](https://github.com/StanfordBDHG/ResearchKitOnFHIR) because it always render groups of questions in a paginated manner whether or not the extension is present, but does lead to [Android FHIR](https://github.com/google/android-fhir) paginating as expected.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
