### PR TITLE
Removes sublabel editor

### DIFF
--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -36,7 +36,6 @@ import { ValidationErrors } from '../../helpers/orphanValidation';
 import {
     canTypeBeRequired,
     canTypeBeValidated,
-    canTypeHaveSublabel,
     getItemDisplayType,
 } from '../../helpers/questionTypeFeatures';
 import SliderSettings from './SliderSettings/SliderSettings';
@@ -72,10 +71,6 @@ const Question = (props: QuestionProps): JSX.Element => {
                 props.item._text?.extension?.find((x) => x.url === IExtentionType.markdown)?.valueMarkdown || '';
         }
         return labelText || props.item.text || '';
-    };
-
-    const getSublabelText = (): string => {
-        return props.item.extension?.find((x) => x.url === IExtentionType.sublabel)?.valueMarkdown || '';
     };
 
     const convertToPlaintext = (stringToBeConverted: string) => {
@@ -292,24 +287,6 @@ const Question = (props: QuestionProps): JSX.Element => {
                     </FormField>
                 }
                 {isSlider && <SliderSettings item={props.item} /> }
-                {canTypeHaveSublabel(props.item) && (
-                    <FormField label={t('Sublabel')} isOptional>
-                        <MarkdownEditor
-                            data={getSublabelText()}
-                            onBlur={(newValue: string) => {
-                                if (newValue) {
-                                    const newExtension = {
-                                        url: IExtentionType.sublabel,
-                                        valueMarkdown: newValue,
-                                    };
-                                    setItemExtension(props.item, newExtension, props.dispatch);
-                                } else {
-                                    removeItemExtension(props.item, IExtentionType.sublabel, props.dispatch);
-                                }
-                            }}
-                        />
-                    </FormField>
-                )}
                 {respondType()}
             </div>
             <div className="question-addons">


### PR DESCRIPTION
# Removes sublabel editor

Sublabels are a remnant of the original [structor](https://github.com/helsenorge/structor/) project from which this project was forked in 2022. They have not been implemented in either ResearchKitOnFHIR (due to limitations of ResearchKit) or Android FHIR SDK. As a result, users have complained about sublabels they added in the Phoenix builder not rendering in Spezi apps. Since we will not be implementing sublabels at this time we will remove the sublabel editor.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
