### PR TITLE
Add mechanism for creating tooltips

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '\\.(css|less|scss)$': 'identity-obj-proxy',
+    '\\.(css|less|scss|svg|png|jpg|jpeg|gif)$': 'identity-obj-proxy',
   },
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', { useESM: true }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
             },
             "devDependencies": {
                 "@testing-library/jest-dom": "^5.11.9",
-                "@testing-library/react": "^14.3.1",
+                "@testing-library/react": "^15.0.6",
                 "@testing-library/user-event": "^14.6.1",
                 "@types/jest": "^26.0.24",
                 "@types/node": "^20.0.0",
@@ -4061,7 +4061,6 @@
             "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -4082,7 +4081,6 @@
             "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "dequal": "^2.0.3"
             }
@@ -4093,7 +4091,6 @@
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4111,7 +4108,6 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -4127,7 +4123,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4157,97 +4152,28 @@
             }
         },
         "node_modules/@testing-library/react": {
-            "version": "14.3.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
-            "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.6.tgz",
+            "integrity": "sha512-UlbazRtEpQClFOiYp+1BapMT+xyqWMnE+hh9tn5DQ6gmlE7AIZWcGpzZukmDZuFk3By01oiqOf8lRedLS4k6xQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
-                "@testing-library/dom": "^9.0.0",
+                "@testing-library/dom": "^10.0.0",
                 "@types/react-dom": "^18.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             },
             "peerDependencies": {
+                "@types/react": "^18.0.0",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-            "version": "9.3.4",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-            "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/runtime": "^7.12.5",
-                "@types/aria-query": "^5.0.1",
-                "aria-query": "5.1.3",
-                "chalk": "^4.1.0",
-                "dom-accessibility-api": "^0.5.9",
-                "lz-string": "^1.5.0",
-                "pretty-format": "^27.0.2"
             },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/aria-query": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-            "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "deep-equal": "^2.0.5"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@testing-library/user-event": {
@@ -6059,39 +5985,6 @@
                 }
             }
         },
-        "node_modules/deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
-                "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -6156,7 +6049,6 @@
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6382,27 +6274,6 @@
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-iterator-helpers": {
@@ -8219,23 +8090,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/is-arguments": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-array-buffer": {
@@ -10810,23 +10664,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -12246,20 +12083,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/string-length": {
@@ -16117,7 +15940,6 @@
             "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
             "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -16134,95 +15956,8 @@
                     "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
                     "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "dequal": "^2.0.3"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "peer": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "peer": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "5.2.0",
-                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                            "dev": true,
-                            "peer": true
-                        }
-                    }
-                }
-            }
-        },
-        "@testing-library/jest-dom": {
-            "version": "5.11.9",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
-            "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.9.2",
-                "@types/testing-library__jest-dom": "^5.9.1",
-                "aria-query": "^4.2.2",
-                "chalk": "^3.0.0",
-                "css": "^3.0.0",
-                "css.escape": "^1.5.1",
-                "lodash": "^4.17.15",
-                "redent": "^3.0.0"
-            }
-        },
-        "@testing-library/react": {
-            "version": "14.3.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
-            "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.12.5",
-                "@testing-library/dom": "^9.0.0",
-                "@types/react-dom": "^18.0.0"
-            },
-            "dependencies": {
-                "@testing-library/dom": {
-                    "version": "9.3.4",
-                    "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-                    "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.10.4",
-                        "@babel/runtime": "^7.12.5",
-                        "@types/aria-query": "^5.0.1",
-                        "aria-query": "5.1.3",
-                        "chalk": "^4.1.0",
-                        "dom-accessibility-api": "^0.5.9",
-                        "lz-string": "^1.5.0",
-                        "pretty-format": "^27.0.2"
-                    }
-                },
-                "aria-query": {
-                    "version": "5.1.3",
-                    "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-                    "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-                    "dev": true,
-                    "requires": {
-                        "deep-equal": "^2.0.5"
                     }
                 },
                 "chalk": {
@@ -16254,6 +15989,33 @@
                         }
                     }
                 }
+            }
+        },
+        "@testing-library/jest-dom": {
+            "version": "5.11.9",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
+            "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.9.2",
+                "@types/testing-library__jest-dom": "^5.9.1",
+                "aria-query": "^4.2.2",
+                "chalk": "^3.0.0",
+                "css": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "lodash": "^4.17.15",
+                "redent": "^3.0.0"
+            }
+        },
+        "@testing-library/react": {
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.6.tgz",
+            "integrity": "sha512-UlbazRtEpQClFOiYp+1BapMT+xyqWMnE+hh9tn5DQ6gmlE7AIZWcGpzZukmDZuFk3By01oiqOf8lRedLS4k6xQ==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.12.5",
+                "@testing-library/dom": "^10.0.0",
+                "@types/react-dom": "^18.0.0"
             }
         },
         "@testing-library/user-event": {
@@ -17600,32 +17362,6 @@
             "dev": true,
             "requires": {}
         },
-        "deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "dev": true,
-            "requires": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
-                "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            }
-        },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -17669,8 +17405,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -17844,23 +17579,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-        },
-        "es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            }
         },
         "es-iterator-helpers": {
             "version": "1.2.1",
@@ -19177,16 +18895,6 @@
                 "es-errors": "^1.3.0",
                 "hasown": "^2.0.2",
                 "side-channel": "^1.1.0"
-            }
-        },
-        "is-arguments": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-            "dev": true,
-            "requires": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
             }
         },
         "is-array-buffer": {
@@ -21001,16 +20709,6 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
             "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
         },
-        "object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            }
-        },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -22017,16 +21715,6 @@
                     "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
                     "dev": true
                 }
-            }
-        },
-        "stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "dev": true,
-            "requires": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
             }
         },
         "string-length": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^5.11.9",
-        "@testing-library/react": "^14.3.1",
+        "@testing-library/react": "^15.0.6",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^26.0.24",
         "@types/node": "^20.0.0",

--- a/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
+++ b/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
@@ -376,7 +376,7 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
                             {`${t('LinkId is already in use')} `}
                             <button onClick={resetLinkId}>
                                 <img src={UndoIcon} height={16} />
-                                {` ${t('Sett tilbake til opprinnelig verdi')}`}
+                                {` ${t('Reset to original value')}`}
                             </button>
                         </div>
                     )}
@@ -397,7 +397,9 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
                 </div>
             )}
             <div className="horizontal full">
-                <FormField label={t('Definition')}>
+                <FormField 
+                    label={t('Definition')} 
+                    tooltip={t('This element is a URI that refers to an ElementDefinition or to an ObservationDefinition that provides information about this item.')}>
                     <UriField
                         value={item.definition}
                         onBlur={(e) => {

--- a/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
+++ b/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
@@ -384,13 +384,15 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
             </div>
             {canTypeHavePrefix(item) && (
                 <div className="horizontal full">
-                    <FormField label={t('Prefix')}>
-                        <InputField
-                            defaultValue={item.prefix}
-                            onBlur={(e) => {
-                                dispatch(updateItemAction(item.linkId, IItemProperty.prefix, e.target.value));
-                            }}
-                        />
+                    <FormField 
+                        label={t('Prefix')} 
+                        tooltip={t('The label to be displayed in front of an option (e.g. "(a)", or "1.").')}>
+                            <InputField
+                                defaultValue={item.prefix}
+                                onBlur={(e) => {
+                                    dispatch(updateItemAction(item.linkId, IItemProperty.prefix, e.target.value));
+                                }}
+                            />
                     </FormField>
                 </div>
             )}

--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -1,0 +1,46 @@
+.form-field__tooltip-container {
+    position: relative;
+    display: inline-block;
+}
+
+.form-field__help-icon {
+    margin-left: 2px;
+    margin-top: 2px;
+    width: 15px;
+    height: 15px;
+    cursor: help;
+}
+
+.form-field__tooltip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: 5px;
+    padding: 8px 12px;
+    background-color: #333;
+    color: white;
+    font-size: 12px;
+    border-radius: 4px;
+    z-index: 1000;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    min-width: 200px;
+    max-width: 500px;
+    white-space: normal;
+}
+
+.form-field__tooltip-arrow {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #333;
+}
+
+.form-field__sublabel {
+    text-align: left;
+}

--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -3,12 +3,44 @@
     display: inline-block;
 }
 
+.form-field__help-button {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: help;
+    display: inline-block;
+    line-height: 0;
+    font: inherit;
+    color: inherit;
+    text-decoration: none;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+
+.form-field__help-button:focus {
+    outline: 2px solid #007acc;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.form-field__help-button:focus:not(:focus-visible) {
+    outline: none;
+}
+
+.form-field__help-button:focus-visible {
+    outline: 2px solid #007acc;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
 .form-field__help-icon {
     margin-left: 2px;
     margin-top: 2px;
     width: 15px;
     height: 15px;
-    cursor: help;
+    display: block;
 }
 
 .form-field__tooltip {

--- a/src/components/FormField/FormField.test.tsx
+++ b/src/components/FormField/FormField.test.tsx
@@ -56,35 +56,37 @@ describe('FormField', () => {
 
     it('renders tooltip icon when tooltip is provided', () => {
         renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip" />);
-        const helpIcon = screen.getByAltText('Help');
+        const helpButton = screen.getByRole('button', { name: 'Show help information' });
+        expect(helpButton).toBeInTheDocument();
+        const helpIcon = helpButton.querySelector('.form-field__help-icon');
         expect(helpIcon).toBeInTheDocument();
         expect(helpIcon).toHaveClass('form-field__help-icon');
     });
 
     it('does not render tooltip icon when tooltip is not provided', () => {
         renderWithI18n(<FormField label="Test Label" />);
-        expect(screen.queryByAltText('Help')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Show help information' })).not.toBeInTheDocument();
     });
 
     it('shows tooltip on mouse enter and hides on mouse leave', async () => {
         const user = userEvent.setup();
         renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip content" />);
         
-        const helpIcon = screen.getByAltText('Help');
+        const helpButton = screen.getByRole('button', { name: 'Show help information' });
         
         // Tooltip should not be visible initially
         expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
         
         // Show tooltip on mouse enter
         await act(async () => {
-            await user.hover(helpIcon);
+            await user.hover(helpButton);
         });
         expect(screen.getByText('Test tooltip content')).toBeInTheDocument();
         expect(screen.getByText('Test tooltip content')).toHaveClass('form-field__tooltip');
         
         // Hide tooltip on mouse leave
         await act(async () => {
-            await user.unhover(helpIcon);
+            await user.unhover(helpButton);
         });
         expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
     });
@@ -93,20 +95,20 @@ describe('FormField', () => {
         const user = userEvent.setup();
         renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip content" />);
         
-        const helpIcon = screen.getByAltText('Help');
+        const helpButton = screen.getByRole('button', { name: 'Show help information' });
         
         // Tooltip should not be visible initially
         expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
         
         // Show tooltip on click
         await act(async () => {
-            await user.click(helpIcon);
+            await user.click(helpButton);
         });
         expect(screen.getByText('Test tooltip content')).toBeInTheDocument();
         
         // Hide tooltip on second click
         await act(async () => {
-            await user.click(helpIcon);
+            await user.click(helpButton);
         });
         expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
     });
@@ -115,9 +117,9 @@ describe('FormField', () => {
         const user = userEvent.setup();
         renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip content" />);
         
-        const helpIcon = screen.getByAltText('Help');
+        const helpButton = screen.getByRole('button', { name: 'Show help information' });
         await act(async () => {
-            await user.click(helpIcon);
+            await user.click(helpButton);
         });
         
         const tooltipArrow = document.querySelector('.form-field__tooltip-arrow');
@@ -140,12 +142,12 @@ describe('FormField', () => {
         expect(screen.getByText('Test Label')).toBeInTheDocument();
         expect(screen.getByText('Test sublabel')).toBeInTheDocument();
         expect(screen.getByText(/optional/i)).toBeInTheDocument();
-        expect(screen.getByAltText('Help')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Show help information' })).toBeInTheDocument();
         expect(screen.getByPlaceholderText('Test input')).toBeInTheDocument();
         
         // Show tooltip
         await act(async () => {
-            await user.click(screen.getByAltText('Help'));
+            await user.click(screen.getByRole('button', { name: 'Show help information' }));
         });
         expect(screen.getByText('Test tooltip')).toBeInTheDocument();
     });

--- a/src/components/FormField/FormField.test.tsx
+++ b/src/components/FormField/FormField.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../helpers/i18n';
+import FormField from './FormField';
+
+// Mock the help icon since it's imported as an SVG
+jest.mock('../../images/icons/help-circle-outline.svg', () => 'help-icon-mock');
+
+const renderWithI18n = (component: React.ReactElement) => {
+    return render(
+        <I18nextProvider i18n={i18n}>
+            {component}
+        </I18nextProvider>
+    );
+};
+
+describe('FormField', () => {
+    it('renders without label when none provided', () => {
+        renderWithI18n(<FormField />);
+        const formField = document.querySelector('.form-field');
+        expect(formField).toBeInTheDocument();
+        expect(screen.queryByRole('label')).not.toBeInTheDocument();
+    });
+
+    it('renders with label', () => {
+        renderWithI18n(<FormField label="Test Label" />);
+        expect(screen.getByText('Test Label')).toBeInTheDocument();
+    });
+
+    it('renders with sublabel', () => {
+        renderWithI18n(<FormField label="Test Label" sublabel="Test sublabel" />);
+        expect(screen.getByText('Test sublabel')).toBeInTheDocument();
+        expect(screen.getByText('Test sublabel')).toHaveClass('form-field__sublabel');
+    });
+
+    it('renders children content', () => {
+        renderWithI18n(
+            <FormField label="Test Label">
+                <input type="text" placeholder="Test input" />
+            </FormField>
+        );
+        expect(screen.getByPlaceholderText('Test input')).toBeInTheDocument();
+    });
+
+    it('shows optional indicator when isOptional is true', () => {
+        renderWithI18n(<FormField label="Test Label" isOptional={true} />);
+        expect(screen.getByText(/optional/i)).toBeInTheDocument();
+        expect(screen.getByText(/optional/i)).toHaveClass('form-field__optional');
+    });
+
+    it('does not show optional indicator when isOptional is false', () => {
+        renderWithI18n(<FormField label="Test Label" isOptional={false} />);
+        expect(screen.queryByText(/optional/i)).not.toBeInTheDocument();
+    });
+
+    it('renders tooltip icon when tooltip is provided', () => {
+        renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip" />);
+        const helpIcon = screen.getByAltText('Help');
+        expect(helpIcon).toBeInTheDocument();
+        expect(helpIcon).toHaveClass('form-field__help-icon');
+    });
+
+    it('does not render tooltip icon when tooltip is not provided', () => {
+        renderWithI18n(<FormField label="Test Label" />);
+        expect(screen.queryByAltText('Help')).not.toBeInTheDocument();
+    });
+
+    it('shows tooltip on mouse enter and hides on mouse leave', async () => {
+        const user = userEvent.setup();
+        renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip content" />);
+        
+        const helpIcon = screen.getByAltText('Help');
+        
+        // Tooltip should not be visible initially
+        expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
+        
+        // Show tooltip on mouse enter
+        await act(async () => {
+            await user.hover(helpIcon);
+        });
+        expect(screen.getByText('Test tooltip content')).toBeInTheDocument();
+        expect(screen.getByText('Test tooltip content')).toHaveClass('form-field__tooltip');
+        
+        // Hide tooltip on mouse leave
+        await act(async () => {
+            await user.unhover(helpIcon);
+        });
+        expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
+    });
+
+    it('toggles tooltip on click', async () => {
+        const user = userEvent.setup();
+        renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip content" />);
+        
+        const helpIcon = screen.getByAltText('Help');
+        
+        // Tooltip should not be visible initially
+        expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
+        
+        // Show tooltip on click
+        await act(async () => {
+            await user.click(helpIcon);
+        });
+        expect(screen.getByText('Test tooltip content')).toBeInTheDocument();
+        
+        // Hide tooltip on second click
+        await act(async () => {
+            await user.click(helpIcon);
+        });
+        expect(screen.queryByText('Test tooltip content')).not.toBeInTheDocument();
+    });
+
+    it('renders tooltip arrow when tooltip is shown', async () => {
+        const user = userEvent.setup();
+        renderWithI18n(<FormField label="Test Label" tooltip="Test tooltip content" />);
+        
+        const helpIcon = screen.getByAltText('Help');
+        await act(async () => {
+            await user.click(helpIcon);
+        });
+        
+        const tooltipArrow = document.querySelector('.form-field__tooltip-arrow');
+        expect(tooltipArrow).toBeInTheDocument();
+    });
+
+    it('renders all props together', async () => {
+        const user = userEvent.setup();
+        renderWithI18n(
+            <FormField 
+                label="Test Label" 
+                sublabel="Test sublabel"
+                tooltip="Test tooltip"
+                isOptional={true}
+            >
+                <input type="text" placeholder="Test input" />
+            </FormField>
+        );
+        
+        expect(screen.getByText('Test Label')).toBeInTheDocument();
+        expect(screen.getByText('Test sublabel')).toBeInTheDocument();
+        expect(screen.getByText(/optional/i)).toBeInTheDocument();
+        expect(screen.getByAltText('Help')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Test input')).toBeInTheDocument();
+        
+        // Show tooltip
+        await act(async () => {
+            await user.click(screen.getByAltText('Help'));
+        });
+        expect(screen.getByText('Test tooltip')).toBeInTheDocument();
+    });
+});

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import HelpIcon from '../../images/icons/help-circle-outline.svg';
+import './FormField.css';
 
 type Props = {
     label?: string;
@@ -21,62 +22,26 @@ const FormField = ({ label, sublabel, tooltip, isOptional, children }: Props): J
                     <span>{label}</span>
                     {isOptional && <span className="form-field__optional">{` (${t('Optional')})`}</span>}
                     {tooltip && (
-                        <span style={{ position: 'relative', display: 'inline-block' }}>
+                        <span className="form-field__tooltip-container">
                             <img 
                                 src={HelpIcon}
                                 alt="Help"
-                                style={{
-                                    marginLeft: '2px',
-                                    marginTop: '2px',
-                                    width: '15px',
-                                    height: '15px',
-                                    cursor: 'help'
-                                }}
+                                className="form-field__help-icon"
                                 onMouseEnter={() => setShowTooltip(true)}
                                 onMouseLeave={() => setShowTooltip(false)}
                                 onClick={() => setShowTooltip(!showTooltip)}
                                 />
                             {showTooltip && (
-                                <div
-                                    style={{
-                                        position: 'absolute',
-                                        bottom: '100%',
-                                        left: '50%',
-                                        transform: 'translateX(-50%)',
-                                        marginBottom: '5px',
-                                        padding: '8px 12px',
-                                        backgroundColor: '#333',
-                                        color: 'white',
-                                        fontSize: '12px',
-                                        borderRadius: '4px',
-                                        zIndex: 1000,
-                                        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                                        minWidth: '200px',
-                                        maxWidth: '500px',
-                                        whiteSpace: 'normal'
-                                    }}
-                                >
+                                <div className="form-field__tooltip">
                                     {tooltip}
-                                    <div
-                                        style={{
-                                            position: 'absolute',
-                                            top: '100%',
-                                            left: '50%',
-                                            transform: 'translateX(-50%)',
-                                            width: 0,
-                                            height: 0,
-                                            borderLeft: '5px solid transparent',
-                                            borderRight: '5px solid transparent',
-                                            borderTop: '5px solid #333'
-                                        }}
-                                    />
+                                    <div className="form-field__tooltip-arrow" />
                                 </div>
                             )}
                         </span>
                     )}
                 </label>
             )}
-            {sublabel && <div style={{textAlign: 'left'}}>{sublabel}</div>}
+            {sublabel && <div className="form-field__sublabel">{sublabel}</div>}
             {children}
         </div>
     );

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -1,14 +1,16 @@
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import HelpIcon from '../../images/icons/help-circle-outline.svg';
 
 type Props = {
     label?: string;
     sublabel?: string;
+    tooltip?: string;
     isOptional?: boolean;
     children?: ReactNode;
 };
 
-const FormField = ({ label, sublabel, isOptional, children }: Props): JSX.Element => {
+const FormField = ({ label, sublabel, tooltip, isOptional, children }: Props): JSX.Element => {
     const { t } = useTranslation();
 
     return (
@@ -17,6 +19,20 @@ const FormField = ({ label, sublabel, isOptional, children }: Props): JSX.Elemen
                 <label>
                     <span>{label}</span>
                     {isOptional && <span className="form-field__optional">{` (${t('Optional')})`}</span>}
+                    {tooltip && (
+                        <img 
+                            src={HelpIcon}
+                            alt="Help"
+                            title={tooltip}
+                            style={{
+                                marginLeft: '2px',
+                                marginTop: '2px',
+                                width: '15px',
+                                height: '15px',
+                                cursor: 'help'
+                            }}
+                            />
+                    )}
                 </label>
             )}
             {sublabel && <div style={{textAlign: 'left'}}>{sublabel}</div>}

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -23,14 +23,23 @@ const FormField = ({ label, sublabel, tooltip, isOptional, children }: Props): J
                     {isOptional && <span className="form-field__optional">{` (${t('Optional')})`}</span>}
                     {tooltip && (
                         <span className="form-field__tooltip-container">
-                            <img 
-                                src={HelpIcon}
-                                alt="Help"
-                                className="form-field__help-icon"
+                            <button 
+                                type="button"
+                                className="form-field__help-button"
                                 onMouseEnter={() => setShowTooltip(true)}
                                 onMouseLeave={() => setShowTooltip(false)}
                                 onClick={() => setShowTooltip(!showTooltip)}
+                                aria-label="Show help information"
+                                aria-expanded={showTooltip}
+                                aria-describedby={showTooltip ? "tooltip-content" : undefined}
+                            >
+                                <img 
+                                    src={HelpIcon}
+                                    alt=""
+                                    className="form-field__help-icon"
+                                    aria-hidden="true"
                                 />
+                            </button>
                             {showTooltip && (
                                 <div className="form-field__tooltip">
                                     {tooltip}

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import HelpIcon from '../../images/icons/help-circle-outline.svg';
 
@@ -12,6 +12,7 @@ type Props = {
 
 const FormField = ({ label, sublabel, tooltip, isOptional, children }: Props): JSX.Element => {
     const { t } = useTranslation();
+    const [showTooltip, setShowTooltip] = useState(false);
 
     return (
         <div className="form-field">
@@ -20,18 +21,58 @@ const FormField = ({ label, sublabel, tooltip, isOptional, children }: Props): J
                     <span>{label}</span>
                     {isOptional && <span className="form-field__optional">{` (${t('Optional')})`}</span>}
                     {tooltip && (
-                        <img 
-                            src={HelpIcon}
-                            alt="Help"
-                            title={tooltip}
-                            style={{
-                                marginLeft: '2px',
-                                marginTop: '2px',
-                                width: '15px',
-                                height: '15px',
-                                cursor: 'help'
-                            }}
-                            />
+                        <span style={{ position: 'relative', display: 'inline-block' }}>
+                            <img 
+                                src={HelpIcon}
+                                alt="Help"
+                                style={{
+                                    marginLeft: '2px',
+                                    marginTop: '2px',
+                                    width: '15px',
+                                    height: '15px',
+                                    cursor: 'help'
+                                }}
+                                onMouseEnter={() => setShowTooltip(true)}
+                                onMouseLeave={() => setShowTooltip(false)}
+                                onClick={() => setShowTooltip(!showTooltip)}
+                                />
+                            {showTooltip && (
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        bottom: '100%',
+                                        left: '50%',
+                                        transform: 'translateX(-50%)',
+                                        marginBottom: '5px',
+                                        padding: '8px 12px',
+                                        backgroundColor: '#333',
+                                        color: 'white',
+                                        fontSize: '12px',
+                                        borderRadius: '4px',
+                                        zIndex: 1000,
+                                        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+                                        minWidth: '200px',
+                                        maxWidth: '500px',
+                                        whiteSpace: 'normal'
+                                    }}
+                                >
+                                    {tooltip}
+                                    <div
+                                        style={{
+                                            position: 'absolute',
+                                            top: '100%',
+                                            left: '50%',
+                                            transform: 'translateX(-50%)',
+                                            width: 0,
+                                            height: 0,
+                                            borderLeft: '5px solid transparent',
+                                            borderRight: '5px solid transparent',
+                                            borderTop: '5px solid #333'
+                                        }}
+                                    />
+                                </div>
+                            )}
+                        </span>
                     )}
                 </label>
             )}

--- a/src/components/Metadata/MetadataEditor.tsx
+++ b/src/components/Metadata/MetadataEditor.tsx
@@ -32,36 +32,7 @@ const MetadataEditor = (): JSX.Element => {
 
     return (
         <div id="metadata-editor">
-            <FormField label={t('Identifier')}>
-                <InputField
-                    placeholder={t('A unique identifier consisting only of letters, numbers, - and .')}
-                    defaultValue={qMetadata.id}
-                    onChange={(e) => {
-                        setDisplayIdValidationError(!isValidId(e.target.value));
-                    }}
-                    onBlur={(e) => {
-                        if (isValidId(e.target.value)) {
-                            updateMeta(IQuestionnaireMetadataType.id, e.target.value);
-                        }
-                    }}
-                />
-                {displayIdValidationError && (
-                    <div className="msg-error" aria-live="polite">
-                        {t('Id must be 1-64 characters and only letters a-z, numbers, - and .')}
-                    </div>
-                )}
-            </FormField>
-
-            <FormField label={t('URL')}>
-                <input
-                    defaultValue={state.qMetadata.url || ''}
-                    placeholder={t('A unique URL to identify this survey')}
-                    onBlur={(e) => updateMeta(IQuestionnaireMetadataType.url, e.target.value || '')}
-                    pattern="[Hh][Tt][Tt][Pp][Ss]?:\/\/(?:(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)(?:\.(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)*(?:\.(?:[a-zA-Z\u00a1-\uffff]{2,}))(?::\d{2,5})?(?:\/[^\s]*)?"
-                />
-            </FormField>
-
-            <FormField label={`${t('Title')}`}>
+            <FormField label={`${t('Title')}`} tooltip={t('A name for the survey that will be displayed to your users.')}>
                 <input
                     placeholder={t('A human friendly name for this survey')}
                     value={state.qMetadata.title}
@@ -71,7 +42,7 @@ const MetadataEditor = (): JSX.Element => {
                 />
             </FormField>
 
-            <FormField label={t('Name')}>
+            <FormField label={t('Name')} tooltip={t('A natural language name identifying the questionnaire. This name should be usable as an identifier for the module by machine processing applications such as code generation.')}>
                 <InputField
                     placeholder={t('A computer friendly name for this survey')}
                     defaultValue={qMetadata.name}
@@ -93,6 +64,35 @@ const MetadataEditor = (): JSX.Element => {
                 )}
             </FormField>
 
+            <FormField label={t('Identifier')} tooltip={t('A formal identifier that is used to identify this questionnaire when it is represented in other formats, or referenced in a specification, model, design or an instance.')} isOptional>
+                <InputField
+                    placeholder={t('A unique identifier consisting only of letters, numbers, - and .')}
+                    defaultValue={qMetadata.id}
+                    onChange={(e) => {
+                        setDisplayIdValidationError(!isValidId(e.target.value));
+                    }}
+                    onBlur={(e) => {
+                        if (isValidId(e.target.value)) {
+                            updateMeta(IQuestionnaireMetadataType.id, e.target.value);
+                        }
+                    }}
+                />
+                {displayIdValidationError && (
+                    <div className="msg-error" aria-live="polite">
+                        {t('Id must be 1-64 characters and only letters a-z, numbers, - and .')}
+                    </div>
+                )}
+            </FormField>
+
+            <FormField label={t('URL')} isOptional>
+                <input
+                    defaultValue={state.qMetadata.url || ''}
+                    placeholder={t('A unique URL to identify this survey')}
+                    onBlur={(e) => updateMeta(IQuestionnaireMetadataType.url, e.target.value || '')}
+                    pattern="[Hh][Tt][Tt][Pp][Ss]?:\/\/(?:(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)(?:\.(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)*(?:\.(?:[a-zA-Z\u00a1-\uffff]{2,}))(?::\d{2,5})?(?:\/[^\s]*)?"
+                />
+            </FormField>
+
             <FormField label={t('Description')} isOptional>
                 <textarea
                     placeholder={t('A description of your survey')}
@@ -101,7 +101,7 @@ const MetadataEditor = (): JSX.Element => {
                 />
             </FormField>
 
-            <FormField label={t('Version')} isOptional>
+            <FormField label={t('Version')} tooltip={t('The identifier that is used to identify this version of the questionnaire when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the questionnaire author and is not expected to be globally unique.')} isOptional>
                 <InputField
                     placeholder={t('Version number')}
                     defaultValue={qMetadata.version}
@@ -111,7 +111,7 @@ const MetadataEditor = (): JSX.Element => {
                 />
             </FormField>
 
-            <FormField label={t('Date')} isOptional>
+            <FormField label={t('Date last updated')} isOptional>
                 <DatePicker
                     type="date"
                     selected={qMetadata.date ? parseISO(qMetadata.date) : undefined}
@@ -131,13 +131,13 @@ const MetadataEditor = (): JSX.Element => {
                     name={'status-radio'}
                 />
             </FormField>
-            <FormField label={t('Publisher')} isOptional>
+            <FormField label={t('Publisher')} tooltip={t('The name of the organization or individual responsible for the release and ongoing maintenance of the questionnaire.')} isOptional>
                 <InputField
                     defaultValue={qMetadata.publisher || ''}
                     onBlur={(e) => updateMeta(IQuestionnaireMetadataType.publisher, e.target.value)}
                 />
             </FormField>
-            <FormField label={t('Contact (URL to contact address)')} isOptional>
+            <FormField label={t('Contact')} tooltip={t('May be a website, an email address, a telephone number, etc.')} isOptional>
                 <InputField
                     defaultValue={
                         qMetadata.contact && qMetadata.contact.length > 0 ? qMetadata.contact[0].name : ''
@@ -145,13 +145,13 @@ const MetadataEditor = (): JSX.Element => {
                     onBlur={(e) => updateMeta(IQuestionnaireMetadataType.contact, [{ name: e.target.value }])}
                 />
             </FormField>
-            <FormField label={t('Purpose')} isOptional>
+            <FormField label={t('Purpose')} tooltip={t('Explanation of why this questionnaire is needed and why it has been designed as it has.')} isOptional>
                 <MarkdownEditor
                     data={qMetadata.purpose || ''}
                     onBlur={(purpose: string) => updateMeta(IQuestionnaireMetadataType.purpose, purpose)}
                 />
             </FormField>
-            <FormField label={t('Copyright')} isOptional>
+            <FormField label={t('Copyright')} tooltip={t('A copyright statement relating to the questionnaire and/or its contents. Copyright statements are generally legal restrictions on the use and publishing of the questionnaire.')} isOptional>
                 <MarkdownEditor
                     data={qMetadata.copyright || ''}
                     onBlur={(copyright: string) => updateMeta(IQuestionnaireMetadataType.copyright, copyright)}


### PR DESCRIPTION
# Add mechanism for creating tooltips

## :recycle: Current situation & Problem
It is unclear to users what some of the fields are for in the FHIR specification. It would be nice to provide tooltips with help to clarify the usage of these fields.


## :gear: Release Notes
- Adds a prop for passing a text tooltip to a form field, which is displayed as an outlined help icon that displays the tooltip when the user hovers over it.
- Uses this mechanism to add important tooltips based on user feedback.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
