### PR TITLE
Disable markdown in instruction and text items

### DIFF
--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -161,6 +161,8 @@ const Question = (props: QuestionProps): JSX.Element => {
                     {instructionType()}
                 </div>
                 <div className="horizontal">
+                     {/* 
+                     // Disabled because ResearchKit does not support markdown.
                      <FormField>
                         <SwitchBtn
                             label={t('Text formatting')}
@@ -177,7 +179,7 @@ const Question = (props: QuestionProps): JSX.Element => {
                                 }
                             }} 
                         /> 
-                    </FormField>
+                    </FormField> */}
                     {canTypeBeRequired(props.item) && (
                         <FormField>
                             <SwitchBtn


### PR DESCRIPTION
# Disable markdown in instruction and text items

## :recycle: Current situation & Problem
ResearchKit doesn't support markdown in instruction and text items. This option exists because other platforms, namely web based ones, do. However, the vast majority of our current users are using the tool with ResearchKit via ResearchKitOnFHIR, and this is causing confusion because they expect the markdown to be rendered and it does not. Therefore, we think it is better to simply remove this option rather than add a warning about RK support at this time.


## :gear: Release Notes
For now, we will disable the markdown option to clear up confusion and ensure that questionnaires created by this tool will appear properly on ResearchKit. We will not remove the markdown editor, as it used for other fields and can be reintroduced to instruction and text items if ResearchKit is to add markdown support for these types of questions in the future. Users can, of course, still manually write markdown into these fields if the platform they are targeting does support it.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
