### PR TITLE
Hide footer when in application

### DIFF
--- a/src/views/FrontPage.tsx
+++ b/src/views/FrontPage.tsx
@@ -200,13 +200,14 @@ const FrontPage = (): JSX.Element => {
                             variant="secondary"
                         />
                     </div>
+                    <footer className="footer">
+                        <p className="footer-text">
+                            An <a href="https://github.com/StanfordBDHG/Phoenix">open-source project</a> of the <a href="https://bdh.stanford.edu">Biodesign Digital Health</a> team at Stanford University.
+                        </p>
+                    </footer>
                 </>
             )}
-            <footer className="footer">
-                <p className="footer-text">
-                    An <a href="https://github.com/StanfordBDHG/Phoenix">open-source project</a> of the <a href="https://bdh.stanford.edu">Biodesign Digital Health</a> team at Stanford University.
-                </p>
-            </footer>
+
         </>
     );
 };


### PR DESCRIPTION
# Hide footer when in application

## :recycle: Current situation & Problem
Currently the question tree overlaps with the footer, such that the last item is hidden behind the footer.

## :gear: Release Notes
We will only show the footer on the home page and hide it once the user enters the application and starts editing a questionnaire to solve the issue above and to also give them more space to work.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
