### PR TITLE
Switch to @StanfordBDHG fork of `react-sortable-tree`

### DIFF
--- a/decs.d.ts
+++ b/decs.d.ts
@@ -1,1 +1,1 @@
-declare module '@nosferatu500/react-sortable-tree';
+declare module '@stanfordbdhg/react-sortable-tree';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@ckeditor/ckeditor5-react": "^3.0.0",
                 "@helsenorge/ckeditor5-build-markdown": "^24.0.0",
-                "@nosferatu500/react-sortable-tree": "^4.4.0",
+                "@stanfordbdhg/react-sortable-tree": "^5.0.1",
                 "@types/remove-markdown": "^0.3.4",
                 "axios": "^1.8.2",
                 "crypto-js": "^4.2.0",
@@ -3676,43 +3676,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@nosferatu500/react-dnd-scrollzone": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@nosferatu500/react-dnd-scrollzone/-/react-dnd-scrollzone-2.0.10.tgz",
-            "integrity": "sha512-PBJtyBQrm47ifesOfIOsJd2SaxSpjkfKSoQOHewkI4UeYLyEc4hX0BY3vlVxW0zzak2+IneJghmGnp5lznVo6A==",
-            "dependencies": {
-                "hoist-non-react-statics": "^3.3.2",
-                "lodash.throttle": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "react": ">=17.0.2",
-                "react-dnd": "14.0.4",
-                "react-dom": ">=17.0.2"
-            }
-        },
-        "node_modules/@nosferatu500/react-sortable-tree": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@nosferatu500/react-sortable-tree/-/react-sortable-tree-4.4.0.tgz",
-            "integrity": "sha512-TN3IYLM1y+ZZAM3ulMXnxwcwX6TPokTczkf3UZ9h0dZ/GE3wSlC1Db4crFjvrEgyHWRGX73lA779Um9wtS9tAQ==",
-            "dependencies": {
-                "@nosferatu500/react-dnd-scrollzone": "^2.0.10",
-                "lodash.isequal": "^4.5.0",
-                "react-dnd": "14.0.4",
-                "react-dnd-html5-backend": "^14.1.0",
-                "react-virtuoso": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dnd": "14.0.4",
-                "react-dom": "^17.0.0 || ^18.0.0"
-            }
-        },
         "node_modules/@react-dnd/asap": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
@@ -4053,6 +4016,26 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
+            }
+        },
+        "node_modules/@stanfordbdhg/react-sortable-tree": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@stanfordbdhg/react-sortable-tree/-/react-sortable-tree-5.0.1.tgz",
+            "integrity": "sha512-k4G6ApR6GyJWI//AdKs0m9Dk9AoZVLKN8wLIisJX7kCVKEHH/fDMwBHJTaRkuQgy4PRtieozLdKOHPqHg0Mg2g==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.isequal": "^4.5.0",
+                "react-dnd": "14.0.4",
+                "react-dnd-html5-backend": "^14.1.0",
+                "virtua": "^0.33.7"
+            },
+            "engines": {
+                "node": ">=20.9"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dnd": "14.0.4",
+                "react-dom": "^18.2.0"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -10374,7 +10357,9 @@
         "node_modules/lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+            "license": "MIT"
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -10388,11 +10373,6 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
-        },
-        "node_modules/lodash.throttle": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-            "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
@@ -11291,6 +11271,7 @@
             "version": "14.0.4",
             "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.4.tgz",
             "integrity": "sha512-AFJJXzUIWp5WAhgvI85ESkDCawM0lhoVvfo/lrseLXwFdH3kEO3v8I2C81QPqBW2UEyJBIPStOhPMGYGFtq/bg==",
+            "license": "MIT",
             "dependencies": {
                 "@react-dnd/invariant": "^2.0.0",
                 "@react-dnd/shallowequal": "^2.0.0",
@@ -12915,6 +12896,36 @@
             },
             "engines": {
                 "node": ">=10.12.0"
+            }
+        },
+        "node_modules/virtua": {
+            "version": "0.33.7",
+            "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.33.7.tgz",
+            "integrity": "sha512-IepZaMD/oeEh/ymTqokeQGLrMuRV25+lizPegxVIhOwqX+dEeV9ml1P57Eosok4qiZaeBeQIbIkF9QZrT+EeRQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.14.0",
+                "react-dom": ">=16.14.0",
+                "solid-js": ">=1.0",
+                "svelte": ">=4.0",
+                "vue": ">=3.2"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "solid-js": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vite": {
@@ -15718,27 +15729,6 @@
                 "fastq": "^1.6.0"
             }
         },
-        "@nosferatu500/react-dnd-scrollzone": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@nosferatu500/react-dnd-scrollzone/-/react-dnd-scrollzone-2.0.10.tgz",
-            "integrity": "sha512-PBJtyBQrm47ifesOfIOsJd2SaxSpjkfKSoQOHewkI4UeYLyEc4hX0BY3vlVxW0zzak2+IneJghmGnp5lznVo6A==",
-            "requires": {
-                "hoist-non-react-statics": "^3.3.2",
-                "lodash.throttle": "^4.1.1"
-            }
-        },
-        "@nosferatu500/react-sortable-tree": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@nosferatu500/react-sortable-tree/-/react-sortable-tree-4.4.0.tgz",
-            "integrity": "sha512-TN3IYLM1y+ZZAM3ulMXnxwcwX6TPokTczkf3UZ9h0dZ/GE3wSlC1Db4crFjvrEgyHWRGX73lA779Um9wtS9tAQ==",
-            "requires": {
-                "@nosferatu500/react-dnd-scrollzone": "^2.0.10",
-                "lodash.isequal": "^4.5.0",
-                "react-dnd": "14.0.4",
-                "react-dnd-html5-backend": "^14.1.0",
-                "react-virtuoso": "^4.3.1"
-            }
-        },
         "@react-dnd/asap": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
@@ -15933,6 +15923,17 @@
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^3.0.0"
+            }
+        },
+        "@stanfordbdhg/react-sortable-tree": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@stanfordbdhg/react-sortable-tree/-/react-sortable-tree-5.0.1.tgz",
+            "integrity": "sha512-k4G6ApR6GyJWI//AdKs0m9Dk9AoZVLKN8wLIisJX7kCVKEHH/fDMwBHJTaRkuQgy4PRtieozLdKOHPqHg0Mg2g==",
+            "requires": {
+                "lodash.isequal": "^4.5.0",
+                "react-dnd": "14.0.4",
+                "react-dnd-html5-backend": "^14.1.0",
+                "virtua": "^0.33.7"
             }
         },
         "@testing-library/dom": {
@@ -20496,7 +20497,7 @@
         "lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -20509,11 +20510,6 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
-        },
-        "lodash.throttle": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-            "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -22280,6 +22276,12 @@
                 "@types/istanbul-lib-coverage": "^2.0.1",
                 "convert-source-map": "^2.0.0"
             }
+        },
+        "virtua": {
+            "version": "0.33.7",
+            "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.33.7.tgz",
+            "integrity": "sha512-IepZaMD/oeEh/ymTqokeQGLrMuRV25+lizPegxVIhOwqX+dEeV9ml1P57Eosok4qiZaeBeQIbIkF9QZrT+EeRQ==",
+            "requires": {}
         },
         "vite": {
             "version": "6.3.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@ckeditor/ckeditor5-react": "^3.0.0",
         "@helsenorge/ckeditor5-build-markdown": "^24.0.0",
-        "@nosferatu500/react-sortable-tree": "^4.4.0",
+        "@stanfordbdhg/react-sortable-tree": "^5.0.1",
         "@types/remove-markdown": "^0.3.4",
         "axios": "^1.8.2",
         "crypto-js": "^4.2.0",

--- a/src/components/AnchorMenu/AnchorMenu.tsx
+++ b/src/components/AnchorMenu/AnchorMenu.tsx
@@ -13,8 +13,7 @@ import {
     updateMarkedLinkIdAction,
 } from '../../store/treeStore/treeActions';
 import { ValidationErrors } from '../../helpers/orphanValidation';
-import { SortableTreeWithoutDndContext as SortableTree } from '@nosferatu500/react-sortable-tree';
-import '@nosferatu500/react-sortable-tree/style.css';
+import { SortableTreeWithoutDndContext as SortableTree } from '@stanfordbdhg/react-sortable-tree';
 import { isIgnorableItem } from '../../helpers/itemControl';
 import { generateItemButtons } from './ItemButtons/ItemButtons';
 import { canTypeHaveChildren, getInitialItemConfig } from '../../helpers/questionTypeFeatures';


### PR DESCRIPTION
# Switch to @StanfordBDHG fork of `react-sortable-tree`

## :recycle: Current situation & Problem
The project currently uses react-sortable-tree to render the tree structure of the questionnaire. We are currently using [this fork](https://github.com/nosferatu500/react-sortable-tree) of the [original project](https://github.com/frontend-collective/react-sortable-tree). Both of these are now archived, and neither support React 19, so we have now made [our own fork](https://github.com/stanfordbdhg/react-sortable-tree) where we can continue maintenance of this library, as there is no suitable alternative that would not require a major refactor. (Issue #90)


## :gear: Release Notes
Switches to using https://www.npmjs.com/package/@stanfordbdhg/react-sortable-tree because the original project is now archived as described above.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
