### PR TITLE
Preserve existing code values with user-controlled sync option

### DIFF
--- a/src/components/AnswerOption/DraggableAnswerOptions.test.tsx
+++ b/src/components/AnswerOption/DraggableAnswerOptions.test.tsx
@@ -4,7 +4,14 @@ import DraggableAnswerOptions from './DraggableAnswerOptions';
 import { QuestionnaireItem, QuestionnaireItemAnswerOption } from '../../types/fhir';
 import { IItemProperty } from '../../types/IQuestionnareItemType';
 
-// Mock drag and drop context
+// Mock translation hook
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+// Mock drag and drop context (minimal mocking for functionality)
 jest.mock('react-beautiful-dnd', () => ({
     DragDropContext: ({ children }: any) => children,
     Droppable: ({ children }: any) => children({
@@ -16,25 +23,6 @@ jest.mock('react-beautiful-dnd', () => ({
         draggableProps: {},
         dragHandleProps: {},
     }, { isDragging: false }),
-}));
-
-// Mock AnswerOption component
-jest.mock('./AnswerOption', () => ({
-    __esModule: true,
-    default: ({ changeDisplay, changeCode, answerOption }: any) => (
-        <div data-testid={`answer-option-${answerOption.valueCoding?.id}`}>
-            <input
-                data-testid={`display-input-${answerOption.valueCoding?.id}`}
-                defaultValue={answerOption.valueCoding?.display}
-                onBlur={changeDisplay}
-            />
-            <input
-                data-testid={`code-input-${answerOption.valueCoding?.id}`}
-                defaultValue={answerOption.valueCoding?.code}
-                onBlur={changeCode}
-            />
-        </div>
-    ),
 }));
 
 describe('DraggableAnswerOptions', () => {
@@ -113,7 +101,7 @@ describe('DraggableAnswerOptions', () => {
         );
 
         // Sync should be enabled by default
-        const displayInput = screen.getByTestId('display-input-1');
+        const displayInput = screen.getByDisplayValue('Option 1');
         await user.clear(displayInput);
         await user.type(displayInput, 'New Display Text');
         await user.tab(); // Trigger blur event
@@ -153,7 +141,7 @@ describe('DraggableAnswerOptions', () => {
         mockDispatchUpdateItem.mockClear();
 
         // Change display text
-        const displayInput = screen.getByTestId('display-input-1');
+        const displayInput = screen.getByDisplayValue('Option 1');
         await user.clear(displayInput);
         await user.type(displayInput, 'New Display Text');
         await user.tab(); // Trigger blur event
@@ -186,12 +174,10 @@ describe('DraggableAnswerOptions', () => {
             />
         );
 
-        expect(screen.getByTestId('answer-option-1')).toBeInTheDocument();
-        expect(screen.getByTestId('answer-option-2')).toBeInTheDocument();
-        expect(screen.getByTestId('display-input-1')).toBeInTheDocument();
-        expect(screen.getByTestId('code-input-1')).toBeInTheDocument();
-        expect(screen.getByTestId('display-input-2')).toBeInTheDocument();
-        expect(screen.getByTestId('code-input-2')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Option 1')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Option 2')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('opt1')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('opt2')).toBeInTheDocument();
     });
 
     it('handles empty answer options gracefully', () => {

--- a/src/components/AnswerOption/DraggableAnswerOptions.test.tsx
+++ b/src/components/AnswerOption/DraggableAnswerOptions.test.tsx
@@ -1,0 +1,228 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DraggableAnswerOptions from './DraggableAnswerOptions';
+import { QuestionnaireItem, QuestionnaireItemAnswerOption } from '../../types/fhir';
+import { IItemProperty } from '../../types/IQuestionnareItemType';
+
+// Mock drag and drop context
+jest.mock('react-beautiful-dnd', () => ({
+    DragDropContext: ({ children }: any) => children,
+    Droppable: ({ children }: any) => children({
+        innerRef: jest.fn(),
+        placeholder: null,
+    }, { isDraggingOver: false }),
+    Draggable: ({ children }: any) => children({
+        innerRef: jest.fn(),
+        draggableProps: {},
+        dragHandleProps: {},
+    }, { isDragging: false }),
+}));
+
+// Mock AnswerOption component
+jest.mock('./AnswerOption', () => ({
+    __esModule: true,
+    default: ({ changeDisplay, changeCode, answerOption }: any) => (
+        <div data-testid={`answer-option-${answerOption.valueCoding?.id}`}>
+            <input
+                data-testid={`display-input-${answerOption.valueCoding?.id}`}
+                defaultValue={answerOption.valueCoding?.display}
+                onBlur={changeDisplay}
+            />
+            <input
+                data-testid={`code-input-${answerOption.valueCoding?.id}`}
+                defaultValue={answerOption.valueCoding?.code}
+                onBlur={changeCode}
+            />
+        </div>
+    ),
+}));
+
+describe('DraggableAnswerOptions', () => {
+    const mockDispatchUpdateItem = jest.fn();
+
+    const createMockAnswerOption = (id: string, display: string, code: string): QuestionnaireItemAnswerOption => ({
+        valueCoding: {
+            id,
+            display,
+            code,
+            system: 'test-system',
+        },
+    });
+
+    const createMockItem = (answerOptions: QuestionnaireItemAnswerOption[]): QuestionnaireItem => ({
+        linkId: 'test-question',
+        type: 'choice',
+        text: 'Test Question',
+        answerOption: answerOptions,
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders sync toggle switch with correct default state', () => {
+        const answerOptions = [
+            createMockAnswerOption('1', 'Option 1', 'opt1'),
+            createMockAnswerOption('2', 'Option 2', 'opt2'),
+        ];
+        const item = createMockItem(answerOptions);
+
+        render(
+            <DraggableAnswerOptions 
+                item={item} 
+                dispatchUpdateItem={mockDispatchUpdateItem} 
+            />
+        );
+
+        expect(screen.getByText('Auto-generate values from title')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeChecked(); // Should default to true
+    });
+
+    it('toggles sync state when switch is clicked', async () => {
+        const user = userEvent.setup();
+        const answerOptions = [createMockAnswerOption('1', 'Option 1', 'opt1')];
+        const item = createMockItem(answerOptions);
+
+        render(
+            <DraggableAnswerOptions 
+                item={item} 
+                dispatchUpdateItem={mockDispatchUpdateItem} 
+            />
+        );
+
+        const toggleSwitch = screen.getByRole('checkbox');
+        expect(toggleSwitch).toBeChecked();
+
+        await user.click(toggleSwitch);
+        expect(toggleSwitch).not.toBeChecked();
+
+        await user.click(toggleSwitch);
+        expect(toggleSwitch).toBeChecked();
+    });
+
+    it('calls updateAnswerOption with sync enabled when toggle is on', async () => {
+        const user = userEvent.setup();
+        const answerOptions = [createMockAnswerOption('1', 'Option 1', 'existing_code')];
+        const item = createMockItem(answerOptions);
+
+        render(
+            <DraggableAnswerOptions 
+                item={item} 
+                dispatchUpdateItem={mockDispatchUpdateItem} 
+            />
+        );
+
+        // Sync should be enabled by default
+        const displayInput = screen.getByTestId('display-input-1');
+        await user.clear(displayInput);
+        await user.type(displayInput, 'New Display Text');
+        await user.tab(); // Trigger blur event
+
+        expect(mockDispatchUpdateItem).toHaveBeenCalledWith(
+            IItemProperty.answerOption,
+            expect.arrayContaining([
+                expect.objectContaining({
+                    valueCoding: expect.objectContaining({
+                        id: '1',
+                        display: 'New Display Text',
+                        code: 'new-display-text', // Should be updated due to sync being enabled
+                    }),
+                }),
+            ])
+        );
+    });
+
+    it('calls updateAnswerOption with sync disabled when toggle is off', async () => {
+        const user = userEvent.setup();
+        const answerOptions = [createMockAnswerOption('1', 'Option 1', 'existing_code')];
+        const item = createMockItem(answerOptions);
+
+        render(
+            <DraggableAnswerOptions 
+                item={item} 
+                dispatchUpdateItem={mockDispatchUpdateItem} 
+            />
+        );
+
+        // Turn off sync
+        const toggleSwitch = screen.getByRole('checkbox');
+        await user.click(toggleSwitch);
+        expect(toggleSwitch).not.toBeChecked();
+
+        // Clear previous mock calls
+        mockDispatchUpdateItem.mockClear();
+
+        // Change display text
+        const displayInput = screen.getByTestId('display-input-1');
+        await user.clear(displayInput);
+        await user.type(displayInput, 'New Display Text');
+        await user.tab(); // Trigger blur event
+
+        expect(mockDispatchUpdateItem).toHaveBeenCalledWith(
+            IItemProperty.answerOption,
+            expect.arrayContaining([
+                expect.objectContaining({
+                    valueCoding: expect.objectContaining({
+                        id: '1',
+                        display: 'New Display Text',
+                        code: 'existing_code', // Should preserve existing code when sync is disabled
+                    }),
+                }),
+            ])
+        );
+    });
+
+    it('renders answer options with correct structure', () => {
+        const answerOptions = [
+            createMockAnswerOption('1', 'Option 1', 'opt1'),
+            createMockAnswerOption('2', 'Option 2', 'opt2'),
+        ];
+        const item = createMockItem(answerOptions);
+
+        render(
+            <DraggableAnswerOptions 
+                item={item} 
+                dispatchUpdateItem={mockDispatchUpdateItem} 
+            />
+        );
+
+        expect(screen.getByTestId('answer-option-1')).toBeInTheDocument();
+        expect(screen.getByTestId('answer-option-2')).toBeInTheDocument();
+        expect(screen.getByTestId('display-input-1')).toBeInTheDocument();
+        expect(screen.getByTestId('code-input-1')).toBeInTheDocument();
+        expect(screen.getByTestId('display-input-2')).toBeInTheDocument();
+        expect(screen.getByTestId('code-input-2')).toBeInTheDocument();
+    });
+
+    it('handles empty answer options gracefully', () => {
+        const item = createMockItem([]);
+
+        render(
+            <DraggableAnswerOptions 
+                item={item} 
+                dispatchUpdateItem={mockDispatchUpdateItem} 
+            />
+        );
+
+        expect(screen.getByText('Auto-generate values from title')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('handles item with no answerOption property', () => {
+        const item: QuestionnaireItem = {
+            linkId: 'test-question',
+            type: 'choice',
+            text: 'Test Question',
+        };
+
+        render(
+            <DraggableAnswerOptions 
+                item={item} 
+                dispatchUpdateItem={mockDispatchUpdateItem} 
+            />
+        );
+
+        expect(screen.getByText('Auto-generate values from title')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+});

--- a/src/components/AnswerOption/DraggableAnswerOptions.tsx
+++ b/src/components/AnswerOption/DraggableAnswerOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     DragDropContext,
     Draggable,
@@ -26,6 +26,7 @@ interface DraggableAnswerOptionsProps {
 }
 
 const DraggableAnswerOptions = ({ item, dispatchUpdateItem }: DraggableAnswerOptionsProps): JSX.Element => {
+    const [syncDisplayWithCode, setSyncDisplayWithCode] = useState(true);
     const handleChange = (result: DropResult) => {
         if (!result.source || !result.destination || !result.draggableId) {
             return;
@@ -55,8 +56,20 @@ const DraggableAnswerOptions = ({ item, dispatchUpdateItem }: DraggableAnswerOpt
     });
 
     return (
-        <DragDropContext onDragEnd={handleChange}>
-            <Droppable droppableId={`droppable-${item.linkId}-answer-options`} type="stuff">
+        <div>
+            <div style={{ marginBottom: '10px' }}>
+                <label>
+                    <input
+                        type="checkbox"
+                        checked={syncDisplayWithCode}
+                        onChange={(e) => setSyncDisplayWithCode(e.target.checked)}
+                        style={{ marginRight: '8px' }}
+                    />
+                    Auto-generate values from title
+                </label>
+            </div>
+            <DragDropContext onDragEnd={handleChange}>
+                <Droppable droppableId={`droppable-${item.linkId}-answer-options`} type="stuff">
                 {(provided, snapshot) => (
                     <div ref={provided.innerRef} style={getListStyle(snapshot.isDraggingOver)}>
                         {item.answerOption?.map((answerOption, index) => {
@@ -81,6 +94,7 @@ const DraggableAnswerOptions = ({ item, dispatchUpdateItem }: DraggableAnswerOpt
                                                         item.answerOption || [],
                                                         answerOption.valueCoding?.id || '',
                                                         event.target.value,
+                                                        syncDisplayWithCode,
                                                     );
                                                     dispatchUpdateItem(IItemProperty.answerOption, newArray);
                                                 }}
@@ -115,6 +129,7 @@ const DraggableAnswerOptions = ({ item, dispatchUpdateItem }: DraggableAnswerOpt
                 )}
             </Droppable>
         </DragDropContext>
+        </div>
     );
 };
 

--- a/src/components/AnswerOption/DraggableAnswerOptions.tsx
+++ b/src/components/AnswerOption/DraggableAnswerOptions.tsx
@@ -16,6 +16,7 @@ import {
 import { QuestionnaireItem, QuestionnaireItemAnswerOption } from '../../types/fhir';
 import { IItemProperty } from '../../types/IQuestionnareItemType';
 import AnswerOption from './AnswerOption';
+import SwitchBtn from '../SwitchBtn/SwitchBtn';
 
 interface DraggableAnswerOptionsProps {
     item: QuestionnaireItem;
@@ -57,16 +58,12 @@ const DraggableAnswerOptions = ({ item, dispatchUpdateItem }: DraggableAnswerOpt
 
     return (
         <div>
-            <div style={{ marginBottom: '10px' }}>
-                <label>
-                    <input
-                        type="checkbox"
-                        checked={syncDisplayWithCode}
-                        onChange={(e) => setSyncDisplayWithCode(e.target.checked)}
-                        style={{ marginRight: '8px' }}
-                    />
-                    Auto-generate values from title
-                </label>
+            <div style={{ marginBottom: '10px', display: 'flex', justifyContent: 'center' }}>
+                <SwitchBtn
+                    value={syncDisplayWithCode}
+                    onChange={() => setSyncDisplayWithCode(!syncDisplayWithCode)}
+                    label="Auto-generate values from title"
+                />
             </div>
             <DragDropContext onDragEnd={handleChange}>
                 <Droppable droppableId={`droppable-${item.linkId}-answer-options`} type="stuff">

--- a/src/helpers/answerOptionHelper.ts
+++ b/src/helpers/answerOptionHelper.ts
@@ -31,15 +31,17 @@ export const updateAnswerOption = (
     displayValue: string,
 ): QuestionnaireItemAnswerOption[] => {
     return values.map((x) => {
-        return x.valueCoding?.id === targetId
-            ? ({
-                  valueCoding: {
-                      ...x.valueCoding,
-                      display: displayValue,
-                      code: removeSpace(displayValue),
-                  },
-              } as QuestionnaireItemAnswerOption)
-            : x;
+        if (x.valueCoding?.id === targetId) {
+            const existingCode = x.valueCoding?.code;
+            return {
+                valueCoding: {
+                    ...x.valueCoding,
+                    display: displayValue,
+                    code: existingCode && existingCode.trim() !== '' ? existingCode : removeSpace(displayValue),
+                },
+            } as QuestionnaireItemAnswerOption;
+        }
+        return x;
     });
 };
 

--- a/src/helpers/answerOptionHelper.ts
+++ b/src/helpers/answerOptionHelper.ts
@@ -29,15 +29,17 @@ export const updateAnswerOption = (
     values: QuestionnaireItemAnswerOption[],
     targetId: string,
     displayValue: string,
+    forceUpdateCode = false,
 ): QuestionnaireItemAnswerOption[] => {
     return values.map((x) => {
         if (x.valueCoding?.id === targetId) {
             const existingCode = x.valueCoding?.code;
+            
             return {
                 valueCoding: {
                     ...x.valueCoding,
                     display: displayValue,
-                    code: existingCode && existingCode.trim() !== '' ? existingCode : removeSpace(displayValue),
+                    code: forceUpdateCode ? removeSpace(displayValue) : existingCode,
                 },
             } as QuestionnaireItemAnswerOption;
         }


### PR DESCRIPTION
# Preserve existing code values with user-controlled sync option

## :recycle: Current situation & Problem
The original behavior automatically overwrote code values when updating display text, making bulk updates easy but causing users to lose custom code values.

## :gear: Release Notes
- Added "Auto-generate values from title" checkbox for user control
- **Defaults to enabled** - preserves original easy-update workflow
- When enabled: automatically syncs code values with display text changes
- When disabled: preserves existing code values, never auto-updating them
- Provides both safety for custom codes and convenience for bulk updates

## :test_tube: Testing
- [x] Verify checkbox defaults to checked
- [x] Test that enabling sync updates codes from display text
- [x] Test that disabling sync preserves existing codes completely
- [x] Confirm TypeScript compilation passes
- [x] Build completes successfully

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).