### PR TITLE
Implement Real-time Form Validation

### DIFF
--- a/src/components/Btn/Btn.css
+++ b/src/components/Btn/Btn.css
@@ -52,6 +52,12 @@
     color: #FFFFFF;
 }
 
+.regular-btn.error {
+    background: #ff4d4f;
+    color: #FFFFFF;
+    cursor: not-allowed;
+}
+
 .btn-group button {
     margin-right: 10px;
 }

--- a/src/components/Btn/Btn.tsx
+++ b/src/components/Btn/Btn.tsx
@@ -6,7 +6,7 @@ type BtnProps = {
     id?: string;
     type?: 'button' | 'submit' | 'reset';
     icon?: 'ion-plus-round' | 'ion-ios-trash' | 'ion-create-outline';
-    variant?: 'primary' | 'secondary';
+    variant?: 'primary' | 'secondary' | 'error';
 };
 
 const Btn = ({ title, onClick, id, type = 'button', icon, variant }: BtnProps): JSX.Element => {

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -72,6 +72,13 @@ const Navbar = ({
     };
 
     function exportToJsonAndDownload() {
+        // Check if there are validation errors that should prevent download
+        if (validationErrors.length > 0) {
+            // Show validation errors modal instead of downloading
+            setShowValidationErrors(true);
+            return;
+        }
+
         const questionnaire = generateQuestionnaire(state);
         const filename = `${getFileName()}.${fileExtension}`;
         const contentType = 'application/json;charset=utf-8;';
@@ -133,7 +140,11 @@ const Navbar = ({
                         );
                         setShowJSONView(!showJSONView);
                     }} />
-                    <Btn title={t('Download')} onClick={() => exportToJsonAndDownload()} />
+                    <Btn 
+                        title={validationErrors.length > 0 ? t('Fix validation errors before downloading') : t('Download')} 
+                        onClick={() => exportToJsonAndDownload()}
+                        variant={validationErrors.length > 0 ? 'error' : undefined}
+                    />
                     <div
                         className="more-menu"
                         tabIndex={0}

--- a/src/components/ValidationErrorsModal/validationErrorsModal.tsx
+++ b/src/components/ValidationErrorsModal/validationErrorsModal.tsx
@@ -15,7 +15,7 @@ export const ValidationErrorsModal = (props: ValidationErrorsModalProps): JSX.El
         <Modal close={props.onClose} title={t('Validation')} bottomCloseText={t('Close')}>
             {props.validationErrors.length > 0 ? (
                 <div className="msg-error">
-                    {t('Found {0} errors. Questions with errors are marked with a red border.').replace(
+                    {t('Found {0} errors. Questions with errors are marked with a red border. Fix these errors to enable downloading.').replace(
                         '{0}',
                         props.validationErrors.length.toString(),
                     )}

--- a/src/hooks/useRealTimeValidation.ts
+++ b/src/hooks/useRealTimeValidation.ts
@@ -1,0 +1,77 @@
+import { useEffect, useMemo } from 'react';
+import { TFunction } from 'react-i18next';
+import { ValidationErrors, validateOrphanedElements, validateTranslations } from '../helpers/orphanValidation';
+import { Items, OrderItem, Languages } from '../store/treeStore/treeStore';
+import { ValueSet } from '../types/fhir';
+
+interface UseRealTimeValidationProps {
+    qOrder: OrderItem[];
+    qItems: Items;
+    qContained: ValueSet[];
+    qAdditionalLanguages?: Languages;
+    t: TFunction<'translation'>;
+    onValidationChange: (validationErrors: ValidationErrors[], translationErrors: ValidationErrors[]) => void;
+    debounceMs?: number;
+}
+
+// Cache for validation results to avoid unnecessary re-runs
+const validationCache = new Map<string, { validationErrors: ValidationErrors[], translationErrors: ValidationErrors[] }>();
+
+function generateCacheKey(qOrder: OrderItem[], qItems: Items, qContained: ValueSet[], qAdditionalLanguages?: Languages): string {
+    // Create a hash-like key based on the current state
+    // This is a simple implementation - in production you might want to use a proper hash function
+    const orderKey = JSON.stringify(qOrder);
+    const itemsKey = JSON.stringify(qItems);
+    const containedKey = JSON.stringify(qContained);
+    const languagesKey = qAdditionalLanguages ? JSON.stringify(qAdditionalLanguages) : 'none';
+    
+    return `${orderKey}|${itemsKey}|${containedKey}|${languagesKey}`;
+}
+
+export const useRealTimeValidation = ({
+    qOrder,
+    qItems,
+    qContained,
+    qAdditionalLanguages,
+    t,
+    onValidationChange,
+    debounceMs = 300
+}: UseRealTimeValidationProps) => {
+    // Generate cache key based on current state
+    const cacheKey = useMemo(() => 
+        generateCacheKey(qOrder, qItems, qContained, qAdditionalLanguages), 
+        [qOrder, qItems, qContained, qAdditionalLanguages]
+    );
+
+    useEffect(() => {
+        // Check cache first
+        const cachedResult = validationCache.get(cacheKey);
+        if (cachedResult) {
+            onValidationChange(cachedResult.validationErrors, cachedResult.translationErrors);
+            return;
+        }
+
+        // Debounce validation
+        const timeoutId = setTimeout(() => {
+            const validationErrors = validateOrphanedElements(t, qOrder, qItems, qContained);
+            const translationErrors = qAdditionalLanguages 
+                ? validateTranslations(t, qOrder, qItems, qAdditionalLanguages) 
+                : [];
+
+            // Cache the results
+            validationCache.set(cacheKey, { validationErrors, translationErrors });
+
+            // Limit cache size to prevent memory leaks
+            if (validationCache.size > 50) {
+                const firstKey = validationCache.keys().next().value;
+                if (firstKey) {
+                    validationCache.delete(firstKey);
+                }
+            }
+
+            onValidationChange(validationErrors, translationErrors);
+        }, debounceMs);
+
+        return () => clearTimeout(timeoutId);
+    }, [cacheKey, t, onValidationChange, debounceMs]);
+};

--- a/src/views/FormBuilder.tsx
+++ b/src/views/FormBuilder.tsx
@@ -9,7 +9,8 @@ import './FormBuilder.css';
 import { ValidationErrors } from '../helpers/orphanValidation';
 import TranslationModal from '../components/Languages/Translation/TranslationModal';
 import MetadataEditor from '../components/Metadata/MetadataEditor';
-import SurveySetup from './SurveySetup'
+import SurveySetup from './SurveySetup';
+import { useRealTimeValidation } from '../hooks/useRealTimeValidation';
 
 type FormBuilderProps = {
     close: () => void
@@ -23,6 +24,19 @@ const FormBuilder = (props: FormBuilderProps): JSX.Element => {
     const [validationErrors, setValidationErrors] = useState<Array<ValidationErrors>>([]);
     const [translationErrors, setTranslationErrors] = useState<Array<ValidationErrors>>([]);
     const [translateLang, setTranslateLang] = useState('');
+
+    // Real-time validation hook
+    useRealTimeValidation({
+        qOrder: state.qOrder,
+        qItems: state.qItems,
+        qContained: state.qContained || [],
+        qAdditionalLanguages: state.qAdditionalLanguages,
+        t,
+        onValidationChange: (newValidationErrors, newTranslationErrors) => {
+            setValidationErrors(newValidationErrors);
+            setTranslationErrors(newTranslationErrors);
+        }
+    });
 
 
     const toggleFormDetails = useCallback(() => {


### PR DESCRIPTION
# Implement Real-time Form Validation

## :recycle: Current situation & Problem
Fixes #70

The current UX flow requires users to find and press the "Validate" button to validate the form, leading to several issues. Validation problems remain undetected until later and take longer to revisit and fix. There is no real-time feedback for changes to ensure errors are properly addressed. Users must perform additional button clicks and workflow steps to ensure a valid form.

## :gear: Release Notes
This implementation adds automatic form validation with real-time feedback. Validation checks run automatically whenever a change to the form is detected. Feedback is provided immediately when validation checks fail. The download option only allows downloading if the form is valid, otherwise displays an error.

Enhanced visual feedback shows a red error state on the download button whenever validation checks fail. Error indicators clear immediately when issues are resolved. The download button prevents downloading if there are FHIR errors and displays an error modal.

Performance is maintained through caching that reduces validation runs when values remain unchanged.

## :books: Documentation
The solution implements a custom React hook `useRealTimeValidation` that automatically triggers validation whenever form state changes. The hook includes debouncing to prevent excessive validation calls and caching to improve performance. The existing validation logic is reused, maintaining consistency with the current validation system.

## :white_check_mark: Testing
All existing tests continue to pass. The implementation reuses existing validation functions ensuring consistent behavior. The build process completes successfully without TypeScript errors.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).