### PR TITLE
Add Language Selector to Survey Metadata

### DIFF
--- a/src/components/Metadata/MetadataEditor.tsx
+++ b/src/components/Metadata/MetadataEditor.tsx
@@ -15,6 +15,8 @@ import { TreeContext } from '../../store/treeStore/treeStore';
 import { updateQuestionnaireMetadataAction } from '../../store/treeStore/treeActions';
 import RadioBtn from '../RadioBtn/RadioBtn';
 import InputField from '../InputField/inputField';
+import Select from '../Select/Select';
+import { supportedLanguages } from '../../helpers/LanguageHelper';
 
 const MetadataEditor = (): JSX.Element => {
     const { t } = useTranslation();
@@ -129,6 +131,30 @@ const MetadataEditor = (): JSX.Element => {
                     checked={qMetadata.status || ''}
                     options={questionnaireStatusOptions}
                     name={'status-radio'}
+                />
+            </FormField>
+
+            <FormField label={t('Language')}>
+                <Select
+                    value={qMetadata.language || ''}
+                    options={supportedLanguages}
+                    onChange={(e) => {
+                        const display = supportedLanguages.find((x) => x.code === e.target.value)?.localDisplay;
+                        const newMeta = {
+                            ...qMetadata.meta,
+                            tag: qMetadata.meta?.tag?.map((x) =>
+                                x.system === 'urn:ietf:bcp:47'
+                                    ? {
+                                          system: 'urn:ietf:bcp:47',
+                                          code: e.target.value,
+                                          display: display,
+                                      }
+                                    : x,
+                            ),
+                        };
+                        updateMeta(IQuestionnaireMetadataType.language, e.target.value);
+                        updateMeta(IQuestionnaireMetadataType.meta, newMeta);
+                    }}
                 />
             </FormField>
             <FormField label={t('Publisher')} tooltip={t('The name of the organization or individual responsible for the release and ongoing maintenance of the questionnaire.')} isOptional>


### PR DESCRIPTION
# Add Language Selector to Survey Metadata

## :recycle: Current situation & Problem
Currently, the language field for questionnaires is initialized to a default value (`en-US`) but there is no UI control in the Survey Metadata modal to change it. Users cannot select the primary language for their questionnaire through the interface.

## :gear: Release Notes
- Added language selector dropdown to the Survey Metadata modal
- Supported languages include: English (US), English (UK), Spanish (Spain/Mexico/US), German, and Swedish
- Language selection updates both the `language` field and the FHIR metadata tag (`urn:ietf:bcp:47`) to maintain FHIR compliance
- The language selector appears after the Status field in the metadata form

## :books: Documentation
The language selector is implemented in the `MetadataEditor` component and uses the existing `supportedLanguages` configuration from `LanguageHelper.ts`. When a language is selected, it updates:
1. The questionnaire's `language` property
2. The metadata tag with system `urn:ietf:bcp:47` containing the language code and display name

## :white_check_mark: Testing
- Manual testing verified the language selector appears in the Survey Metadata modal
- Verified language selection updates both the language field and metadata tag correctly
- Confirmed the selected language persists when reopening the metadata modal

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).