### PR TITLE
dynamically generate supportedLanguages list

### DIFF
--- a/src/components/Languages/LanguageAccordion.tsx
+++ b/src/components/Languages/LanguageAccordion.tsx
@@ -135,7 +135,7 @@ const LanguageAccordion = (props: LanguageAccordionProps): JSX.Element => {
                         value={qMetadata.language || ''}
                         options={supportedLanguages}
                         onChange={(e) => {
-                            const display = supportedLanguages.find((x) => x.code === e.target.value)?.localDisplay;
+                            const display = supportedLanguages.find((x) => x.code === e.target.value)?.display;
                             const newMeta = {
                                 ...qMetadata.meta,
                                 tag: qMetadata.meta?.tag?.map((x) =>

--- a/src/components/Metadata/MetadataEditor.test.tsx
+++ b/src/components/Metadata/MetadataEditor.test.tsx
@@ -27,14 +27,12 @@ describe('Language Selector - Supported Languages', () => {
         const german = supportedLanguages.find(lang => lang.code === 'de-DE');
         expect(german).toBeDefined();
         expect(german?.display).toBe('German');
-        expect(german?.localDisplay).toBe('Deutsch');
     });
 
     it('includes Swedish', () => {
         const swedish = supportedLanguages.find(lang => lang.code === 'sv-SE');
         expect(swedish).toBeDefined();
         expect(swedish?.display).toBe('Swedish');
-        expect(swedish?.localDisplay).toBe('Svenska');
     });
 
     it('does not include custom as a supported language', () => {
@@ -46,10 +44,8 @@ describe('Language Selector - Supported Languages', () => {
         supportedLanguages.forEach(lang => {
             expect(lang).toHaveProperty('code');
             expect(lang).toHaveProperty('display');
-            expect(lang).toHaveProperty('localDisplay');
             expect(typeof lang.code).toBe('string');
             expect(typeof lang.display).toBe('string');
-            expect(typeof lang.localDisplay).toBe('string');
         });
     });
 });
@@ -94,7 +90,7 @@ describe('Language Selector - Custom Language Detection', () => {
 describe('Language Selector - Custom Language Behavior', () => {
     it('custom option should be added to dropdown options at runtime', () => {
         // Simulate what happens in the UI
-        const dropdownOptions = [...supportedLanguages, { code: 'custom', display: 'Custom', localDisplay: 'Custom' }];
+        const dropdownOptions = [...supportedLanguages, { code: 'custom', display: 'Custom' }];
 
         const customOption = dropdownOptions.find(opt => opt.code === 'custom');
         expect(customOption).toBeDefined();

--- a/src/components/Metadata/MetadataEditor.tsx
+++ b/src/components/Metadata/MetadataEditor.tsx
@@ -144,7 +144,7 @@ const MetadataEditor = (): JSX.Element => {
             <FormField label={t('Language')}>
                 <Select
                     value={isCustomLanguage ? 'custom' : qMetadata.language || ''}
-                    options={[...supportedLanguages, { code: 'custom', display: 'Custom', localDisplay: 'Custom' }]}
+                    options={[...supportedLanguages, { code: 'custom', display: 'Custom' }]}
                     onChange={(e) => {
                         if (e.target.value === 'custom') {
                             // Show custom fields
@@ -155,7 +155,7 @@ const MetadataEditor = (): JSX.Element => {
                         }
                         // Hide custom fields when selecting a supported language
                         setShowCustomFields(false);
-                        const display = supportedLanguages.find((x) => x.code === e.target.value)?.localDisplay;
+                        const display = supportedLanguages.find((x) => x.code === e.target.value)?.display;
                         const newMeta = {
                             ...qMetadata.meta,
                             tag: qMetadata.meta?.tag?.map((x) =>

--- a/src/helpers/LanguageHelper.ts
+++ b/src/helpers/LanguageHelper.ts
@@ -8,19 +8,18 @@ import {
 import { Languages, TreeState } from '../store/treeStore/treeStore';
 import { isValidId } from './MetadataHelper';
 import { IExtentionType } from '../types/IQuestionnareItemType';
-import { Extension } from '../types/fhir';
+import { Extension, Languages as SupportedLanguages } from '../types/fhir';
 
-export const INITIAL_LANGUAGE: Language = { code: 'en-US', display: 'English', localDisplay: 'English' };
-
-export const supportedLanguages: Language[] = [
-    INITIAL_LANGUAGE, // en-US
-    { code: 'en-GB', display: 'English (UK)', localDisplay: 'English (UK)' },
-    { code: 'es-ES', display: 'Spanish (Spain)', localDisplay: 'Español (España)' },
-    { code: 'es-MX', display: 'Spanish (Mexico)', localDisplay: 'Español (México)' },
-    { code: 'es-US', display: 'Spanish (US)', localDisplay: 'Español (Estados Unidos)' },
-    { code: 'de-DE', display: 'German', localDisplay: 'Deutsch' },
-    { code: 'sv-SE', display: 'Swedish', localDisplay: 'Svenska' },
-];
+export const supportedLanguages: Language[] = Object.values(SupportedLanguages).reduce((acc, lang) => {
+    if (lang.code !== undefined && lang.display !== undefined) {
+        return [...acc, {
+            code: lang.code!,
+            display: lang.display!
+        } as Language];
+    } else {
+        return acc;
+    }
+}, [] as Language[])
 
 export const getLanguageFromCode = (languageCode: string): Language | undefined => {
     return supportedLanguages.find((x) => x.code.toLowerCase() === languageCode.toLowerCase());

--- a/src/helpers/generateQuestionnaire.ts
+++ b/src/helpers/generateQuestionnaire.ts
@@ -209,7 +209,7 @@ function getLanguageData(qMetadata: IQuestionnaireMetadata, languageCode: string
         language: languageCode,
         meta: {
             ...qMetadata.meta,
-            tag: [{ ...tag[0], code: languageCode, display: getLanguageFromCode(languageCode)?.localDisplay }],
+            tag: [{ ...tag[0], code: languageCode, display: getLanguageFromCode(languageCode)?.display }],
         },
     };
 }

--- a/src/types/LanguageTypes.ts
+++ b/src/types/LanguageTypes.ts
@@ -5,7 +5,6 @@ import { IExtentionType } from './IQuestionnareItemType';
 export type Language = {
     code: string;
     display: string;
-    localDisplay: string;
 };
 
 export enum TranslatableMetadataProperty {


### PR DESCRIPTION
# dynamically generate supportedLanguages list

## :recycle: Current situation & Problem
we [currently hardcode](https://github.com/StanfordBDHG/phoenix/blob/b3bb772423013fc8d931aa6ec7a27df4731b8f91/src/helpers/LanguageHelper.ts#L15-L23) the list of supported languages.
this is not ideal, and we instead should build it up dynamically, based on the data we already gets from our `fhir.ts` definitions.

this PR additionally also removes the `localDisplay` property; we instead now simply always use english. given the fact that the entire rest of the app is english anyway, this seems like a reasonable adjustment.


## :gear: Release Notes
- added support for more languages in questionnaire metadata
- list of supported languages for selection in questionnaire metadata is now generated dynamically based on FHIR definitions


## :books: Documentation
n/a


## :white_check_mark: Testing
existing tests remain in place; no new tests are added.


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
